### PR TITLE
Add comprehensive VitePress documentation site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,7 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 
 # Finder (MacOS) folder config
 .DS_Store
+
+# VitePress
+docs/.vitepress/dist
+docs/.vitepress/cache

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,7 @@
   "editor.formatOnSave": true,
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "cSpell.words": [
+    "bunx",
     "konstantin",
     "kriasoft",
     "modelcontextprotocol",

--- a/README.md
+++ b/README.md
@@ -413,6 +413,9 @@ bun test
 # Build
 bun run build
 
+# Run documentation locally
+bun run docs:dev        # Start VitePress dev server at http://localhost:5173
+
 # Run examples
 bun run example:demo    # Interactive demo
 bun run example:github  # GitHub OAuth example

--- a/bun.lock
+++ b/bun.lock
@@ -8,31 +8,342 @@
       },
       "devDependencies": {
         "@modelcontextprotocol/sdk": "^1.17.3",
-        "@types/bun": "latest",
+        "@types/bun": "^1.2.20",
+        "mermaid": "^11.9.0",
         "prettier": "^3.6.2",
         "publint": "^0.3.12",
         "typescript": "^5.9.2",
+        "vitepress": "^1.6.4",
+        "vitepress-plugin-mermaid": "^2.0.17",
       },
       "peerDependencies": {
         "@modelcontextprotocol/sdk": ">=1.17.0 <2",
         "typescript": ">=5 <6",
       },
+      "optionalPeers": [
+        "@modelcontextprotocol/sdk",
+        "typescript",
+      ],
     },
   },
   "packages": {
+    "@algolia/abtesting": ["@algolia/abtesting@1.1.0", "", { "dependencies": { "@algolia/client-common": "5.35.0", "@algolia/requester-browser-xhr": "5.35.0", "@algolia/requester-fetch": "5.35.0", "@algolia/requester-node-http": "5.35.0" } }, "sha512-sEyWjw28a/9iluA37KLGu8vjxEIlb60uxznfTUmXImy7H5NvbpSO6yYgmgH5KiD7j+zTUUihiST0jEP12IoXow=="],
+
+    "@algolia/autocomplete-core": ["@algolia/autocomplete-core@1.17.7", "", { "dependencies": { "@algolia/autocomplete-plugin-algolia-insights": "1.17.7", "@algolia/autocomplete-shared": "1.17.7" } }, "sha512-BjiPOW6ks90UKl7TwMv7oNQMnzU+t/wk9mgIDi6b1tXpUek7MW0lbNOUHpvam9pe3lVCf4xPFT+lK7s+e+fs7Q=="],
+
+    "@algolia/autocomplete-plugin-algolia-insights": ["@algolia/autocomplete-plugin-algolia-insights@1.17.7", "", { "dependencies": { "@algolia/autocomplete-shared": "1.17.7" }, "peerDependencies": { "search-insights": ">= 1 < 3" } }, "sha512-Jca5Ude6yUOuyzjnz57og7Et3aXjbwCSDf/8onLHSQgw1qW3ALl9mrMWaXb5FmPVkV3EtkD2F/+NkT6VHyPu9A=="],
+
+    "@algolia/autocomplete-preset-algolia": ["@algolia/autocomplete-preset-algolia@1.17.7", "", { "dependencies": { "@algolia/autocomplete-shared": "1.17.7" }, "peerDependencies": { "@algolia/client-search": ">= 4.9.1 < 6", "algoliasearch": ">= 4.9.1 < 6" } }, "sha512-ggOQ950+nwbWROq2MOCIL71RE0DdQZsceqrg32UqnhDz8FlO9rL8ONHNsI2R1MH0tkgVIDKI/D0sMiUchsFdWA=="],
+
+    "@algolia/autocomplete-shared": ["@algolia/autocomplete-shared@1.17.7", "", { "peerDependencies": { "@algolia/client-search": ">= 4.9.1 < 6", "algoliasearch": ">= 4.9.1 < 6" } }, "sha512-o/1Vurr42U/qskRSuhBH+VKxMvkkUVTLU6WZQr+L5lGZZLYWyhdzWjW0iGXY7EkwRTjBqvN2EsR81yCTGV/kmg=="],
+
+    "@algolia/client-abtesting": ["@algolia/client-abtesting@5.35.0", "", { "dependencies": { "@algolia/client-common": "5.35.0", "@algolia/requester-browser-xhr": "5.35.0", "@algolia/requester-fetch": "5.35.0", "@algolia/requester-node-http": "5.35.0" } }, "sha512-uUdHxbfHdoppDVflCHMxRlj49/IllPwwQ2cQ8DLC4LXr3kY96AHBpW0dMyi6ygkn2MtFCc6BxXCzr668ZRhLBQ=="],
+
+    "@algolia/client-analytics": ["@algolia/client-analytics@5.35.0", "", { "dependencies": { "@algolia/client-common": "5.35.0", "@algolia/requester-browser-xhr": "5.35.0", "@algolia/requester-fetch": "5.35.0", "@algolia/requester-node-http": "5.35.0" } }, "sha512-SunAgwa9CamLcRCPnPHx1V2uxdQwJGqb1crYrRWktWUdld0+B2KyakNEeVn5lln4VyeNtW17Ia7V7qBWyM/Skw=="],
+
+    "@algolia/client-common": ["@algolia/client-common@5.35.0", "", {}, "sha512-ipE0IuvHu/bg7TjT2s+187kz/E3h5ssfTtjpg1LbWMgxlgiaZIgTTbyynM7NfpSJSKsgQvCQxWjGUO51WSCu7w=="],
+
+    "@algolia/client-insights": ["@algolia/client-insights@5.35.0", "", { "dependencies": { "@algolia/client-common": "5.35.0", "@algolia/requester-browser-xhr": "5.35.0", "@algolia/requester-fetch": "5.35.0", "@algolia/requester-node-http": "5.35.0" } }, "sha512-UNbCXcBpqtzUucxExwTSfAe8gknAJ485NfPN6o1ziHm6nnxx97piIbcBQ3edw823Tej2Wxu1C0xBY06KgeZ7gA=="],
+
+    "@algolia/client-personalization": ["@algolia/client-personalization@5.35.0", "", { "dependencies": { "@algolia/client-common": "5.35.0", "@algolia/requester-browser-xhr": "5.35.0", "@algolia/requester-fetch": "5.35.0", "@algolia/requester-node-http": "5.35.0" } }, "sha512-/KWjttZ6UCStt4QnWoDAJ12cKlQ+fkpMtyPmBgSS2WThJQdSV/4UWcqCUqGH7YLbwlj3JjNirCu3Y7uRTClxvA=="],
+
+    "@algolia/client-query-suggestions": ["@algolia/client-query-suggestions@5.35.0", "", { "dependencies": { "@algolia/client-common": "5.35.0", "@algolia/requester-browser-xhr": "5.35.0", "@algolia/requester-fetch": "5.35.0", "@algolia/requester-node-http": "5.35.0" } }, "sha512-8oCuJCFf/71IYyvQQC+iu4kgViTODbXDk3m7yMctEncRSRV+u2RtDVlpGGfPlJQOrAY7OONwJlSHkmbbm2Kp/w=="],
+
+    "@algolia/client-search": ["@algolia/client-search@5.35.0", "", { "dependencies": { "@algolia/client-common": "5.35.0", "@algolia/requester-browser-xhr": "5.35.0", "@algolia/requester-fetch": "5.35.0", "@algolia/requester-node-http": "5.35.0" } }, "sha512-FfmdHTrXhIduWyyuko1YTcGLuicVbhUyRjO3HbXE4aP655yKZgdTIfMhZ/V5VY9bHuxv/fGEh3Od1Lvv2ODNTg=="],
+
+    "@algolia/ingestion": ["@algolia/ingestion@1.35.0", "", { "dependencies": { "@algolia/client-common": "5.35.0", "@algolia/requester-browser-xhr": "5.35.0", "@algolia/requester-fetch": "5.35.0", "@algolia/requester-node-http": "5.35.0" } }, "sha512-gPzACem9IL1Co8mM1LKMhzn1aSJmp+Vp434An4C0OBY4uEJRcqsLN3uLBlY+bYvFg8C8ImwM9YRiKczJXRk0XA=="],
+
+    "@algolia/monitoring": ["@algolia/monitoring@1.35.0", "", { "dependencies": { "@algolia/client-common": "5.35.0", "@algolia/requester-browser-xhr": "5.35.0", "@algolia/requester-fetch": "5.35.0", "@algolia/requester-node-http": "5.35.0" } }, "sha512-w9MGFLB6ashI8BGcQoVt7iLgDIJNCn4OIu0Q0giE3M2ItNrssvb8C0xuwJQyTy1OFZnemG0EB1OvXhIHOvQwWw=="],
+
+    "@algolia/recommend": ["@algolia/recommend@5.35.0", "", { "dependencies": { "@algolia/client-common": "5.35.0", "@algolia/requester-browser-xhr": "5.35.0", "@algolia/requester-fetch": "5.35.0", "@algolia/requester-node-http": "5.35.0" } }, "sha512-AhrVgaaXAb8Ue0u2nuRWwugt0dL5UmRgS9LXe0Hhz493a8KFeZVUE56RGIV3hAa6tHzmAV7eIoqcWTQvxzlJeQ=="],
+
+    "@algolia/requester-browser-xhr": ["@algolia/requester-browser-xhr@5.35.0", "", { "dependencies": { "@algolia/client-common": "5.35.0" } }, "sha512-diY415KLJZ6x1Kbwl9u96Jsz0OstE3asjXtJ9pmk1d+5gPuQ5jQyEsgC+WmEXzlec3iuVszm8AzNYYaqw6B+Zw=="],
+
+    "@algolia/requester-fetch": ["@algolia/requester-fetch@5.35.0", "", { "dependencies": { "@algolia/client-common": "5.35.0" } }, "sha512-uydqnSmpAjrgo8bqhE9N1wgcB98psTRRQXcjc4izwMB7yRl9C8uuAQ/5YqRj04U0mMQ+fdu2fcNF6m9+Z1BzDQ=="],
+
+    "@algolia/requester-node-http": ["@algolia/requester-node-http@5.35.0", "", { "dependencies": { "@algolia/client-common": "5.35.0" } }, "sha512-RgLX78ojYOrThJHrIiPzT4HW3yfQa0D7K+MQ81rhxqaNyNBu4F1r+72LNHYH/Z+y9I1Mrjrd/c/Ue5zfDgAEjQ=="],
+
+    "@antfu/install-pkg": ["@antfu/install-pkg@1.1.0", "", { "dependencies": { "package-manager-detector": "^1.3.0", "tinyexec": "^1.0.1" } }, "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ=="],
+
+    "@antfu/utils": ["@antfu/utils@8.1.1", "", {}, "sha512-Mex9nXf9vR6AhcXmMrlz/HVgYYZpVGJ6YlPgwl7UnaFpnshXs6EK/oa5Gpf3CzENMjkvEx2tQtntGnb7UtSTOQ=="],
+
+    "@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
+
+    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.27.1", "", {}, "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow=="],
+
+    "@babel/parser": ["@babel/parser@7.28.3", "", { "dependencies": { "@babel/types": "^7.28.2" }, "bin": "./bin/babel-parser.js" }, "sha512-7+Ey1mAgYqFAx2h0RuoxcQT5+MlG3GTV0TQrgr7/ZliKsm/MNDxVVutlWaziMq7wJNAz8MTqz55XLpWvva6StA=="],
+
+    "@babel/types": ["@babel/types@7.28.2", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.27.1" } }, "sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ=="],
+
+    "@braintree/sanitize-url": ["@braintree/sanitize-url@7.1.1", "", {}, "sha512-i1L7noDNxtFyL5DmZafWy1wRVhGehQmzZaz1HiN5e7iylJMSZR7ekOV7NsIqa5qBldlLrsKv4HbgFUVlQrz8Mw=="],
+
+    "@chevrotain/cst-dts-gen": ["@chevrotain/cst-dts-gen@11.0.3", "", { "dependencies": { "@chevrotain/gast": "11.0.3", "@chevrotain/types": "11.0.3", "lodash-es": "4.17.21" } }, "sha512-BvIKpRLeS/8UbfxXxgC33xOumsacaeCKAjAeLyOn7Pcp95HiRbrpl14S+9vaZLolnbssPIUuiUd8IvgkRyt6NQ=="],
+
+    "@chevrotain/gast": ["@chevrotain/gast@11.0.3", "", { "dependencies": { "@chevrotain/types": "11.0.3", "lodash-es": "4.17.21" } }, "sha512-+qNfcoNk70PyS/uxmj3li5NiECO+2YKZZQMbmjTqRI3Qchu8Hig/Q9vgkHpI3alNjr7M+a2St5pw5w5F6NL5/Q=="],
+
+    "@chevrotain/regexp-to-ast": ["@chevrotain/regexp-to-ast@11.0.3", "", {}, "sha512-1fMHaBZxLFvWI067AVbGJav1eRY7N8DDvYCTwGBiE/ytKBgP8azTdgyrKyWZ9Mfh09eHWb5PgTSO8wi7U824RA=="],
+
+    "@chevrotain/types": ["@chevrotain/types@11.0.3", "", {}, "sha512-gsiM3G8b58kZC2HaWR50gu6Y1440cHiJ+i3JUvcp/35JchYejb2+5MVeJK0iKThYpAa/P2PYFV4hoi44HD+aHQ=="],
+
+    "@chevrotain/utils": ["@chevrotain/utils@11.0.3", "", {}, "sha512-YslZMgtJUyuMbZ+aKvfF3x1f5liK4mWNxghFRv7jqRR9C3R3fAOGTTKvxXDa2Y1s9zSbcpuO0cAxDYsc9SrXoQ=="],
+
+    "@docsearch/css": ["@docsearch/css@3.8.2", "", {}, "sha512-y05ayQFyUmCXze79+56v/4HpycYF3uFqB78pLPrSV5ZKAlDuIAAJNhaRi8tTdRNXh05yxX/TyNnzD6LwSM89vQ=="],
+
+    "@docsearch/js": ["@docsearch/js@3.8.2", "", { "dependencies": { "@docsearch/react": "3.8.2", "preact": "^10.0.0" } }, "sha512-Q5wY66qHn0SwA7Taa0aDbHiJvaFJLOJyHmooQ7y8hlwwQLQ/5WwCcoX0g7ii04Qi2DJlHsd0XXzJ8Ypw9+9YmQ=="],
+
+    "@docsearch/react": ["@docsearch/react@3.8.2", "", { "dependencies": { "@algolia/autocomplete-core": "1.17.7", "@algolia/autocomplete-preset-algolia": "1.17.7", "@docsearch/css": "3.8.2", "algoliasearch": "^5.14.2" }, "peerDependencies": { "@types/react": ">= 16.8.0 < 19.0.0", "react": ">= 16.8.0 < 19.0.0", "react-dom": ">= 16.8.0 < 19.0.0", "search-insights": ">= 1 < 3" }, "optionalPeers": ["@types/react", "react", "react-dom", "search-insights"] }, "sha512-xCRrJQlTt8N9GU0DG4ptwHRkfnSnD/YpdeaXe02iKfqs97TkZJv60yE+1eq/tjPcVnTW8dP5qLP7itifFVV5eg=="],
+
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.21.5", "", { "os": "aix", "cpu": "ppc64" }, "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.21.5", "", { "os": "android", "cpu": "arm" }, "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.21.5", "", { "os": "android", "cpu": "arm64" }, "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.21.5", "", { "os": "android", "cpu": "x64" }, "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.21.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.21.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.21.5", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.21.5", "", { "os": "freebsd", "cpu": "x64" }, "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.21.5", "", { "os": "linux", "cpu": "arm" }, "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.21.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.21.5", "", { "os": "linux", "cpu": "ia32" }, "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.21.5", "", { "os": "linux", "cpu": "ppc64" }, "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.21.5", "", { "os": "linux", "cpu": "s390x" }, "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.21.5", "", { "os": "linux", "cpu": "x64" }, "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.21.5", "", { "os": "none", "cpu": "x64" }, "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.21.5", "", { "os": "openbsd", "cpu": "x64" }, "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.21.5", "", { "os": "sunos", "cpu": "x64" }, "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.21.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.21.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.21.5", "", { "os": "win32", "cpu": "x64" }, "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw=="],
+
+    "@iconify-json/simple-icons": ["@iconify-json/simple-icons@1.2.48", "", { "dependencies": { "@iconify/types": "*" } }, "sha512-EACOtZMoPJtERiAbX1De0asrrCtlwI27+03c9OJlYWsly9w1O5vcD8rTzh+kDPjo+K8FOVnq2Qy+h/CzljSKDA=="],
+
+    "@iconify/types": ["@iconify/types@2.0.0", "", {}, "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg=="],
+
+    "@iconify/utils": ["@iconify/utils@2.3.0", "", { "dependencies": { "@antfu/install-pkg": "^1.0.0", "@antfu/utils": "^8.1.0", "@iconify/types": "^2.0.0", "debug": "^4.4.0", "globals": "^15.14.0", "kolorist": "^1.8.0", "local-pkg": "^1.0.0", "mlly": "^1.7.4" } }, "sha512-GmQ78prtwYW6EtzXRU1rY+KwOKfz32PD7iJh6Iyqw68GiKuoZ2A6pRtzWONz5VQJbp50mEjXh/7NkumtrAgRKA=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@mermaid-js/mermaid-mindmap": ["@mermaid-js/mermaid-mindmap@9.3.0", "", { "dependencies": { "@braintree/sanitize-url": "^6.0.0", "cytoscape": "^3.23.0", "cytoscape-cose-bilkent": "^4.1.0", "cytoscape-fcose": "^2.1.0", "d3": "^7.0.0", "khroma": "^2.0.0", "non-layered-tidy-tree-layout": "^2.0.2" } }, "sha512-IhtYSVBBRYviH1Ehu8gk69pMDF8DSRqXBRDMWrEfHoaMruHeaP2DXA3PBnuwsMaCdPQhlUUcy/7DBLAEIXvCAw=="],
+
+    "@mermaid-js/parser": ["@mermaid-js/parser@0.6.2", "", { "dependencies": { "langium": "3.3.1" } }, "sha512-+PO02uGF6L6Cs0Bw8RpGhikVvMWEysfAyl27qTlroUB8jSWr1lL0Sf6zi78ZxlSnmgSY2AMMKVgghnN9jTtwkQ=="],
+
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.17.3", "", { "dependencies": { "ajv": "^6.12.6", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.23.8", "zod-to-json-schema": "^3.24.1" } }, "sha512-JPwUKWSsbzx+DLFznf/QZ32Qa+ptfbUlHhRLrBQBAFu9iI1iYvizM4p+zhhRDceSsPutXp4z+R/HPVphlIiclg=="],
 
     "@publint/pack": ["@publint/pack@0.1.2", "", {}, "sha512-S+9ANAvUmjutrshV4jZjaiG8XQyuJIZ8a4utWmN/vW1sgQ9IfBnPndwkmQYw53QmouOIytT874u65HEmu6H5jw=="],
 
+    "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.46.2", "", { "os": "android", "cpu": "arm" }, "sha512-Zj3Hl6sN34xJtMv7Anwb5Gu01yujyE/cLBDB2gnHTAHaWS1Z38L7kuSG+oAh0giZMqG060f/YBStXtMH6FvPMA=="],
+
+    "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.46.2", "", { "os": "android", "cpu": "arm64" }, "sha512-nTeCWY83kN64oQ5MGz3CgtPx8NSOhC5lWtsjTs+8JAJNLcP3QbLCtDDgUKQc/Ro/frpMq4SHUaHN6AMltcEoLQ=="],
+
+    "@rollup/rollup-darwin-arm64": ["@rollup/rollup-darwin-arm64@4.46.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-HV7bW2Fb/F5KPdM/9bApunQh68YVDU8sO8BvcW9OngQVN3HHHkw99wFupuUJfGR9pYLLAjcAOA6iO+evsbBaPQ=="],
+
+    "@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.46.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-SSj8TlYV5nJixSsm/y3QXfhspSiLYP11zpfwp6G/YDXctf3Xkdnk4woJIF5VQe0of2OjzTt8EsxnJDCdHd2xMA=="],
+
+    "@rollup/rollup-freebsd-arm64": ["@rollup/rollup-freebsd-arm64@4.46.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-ZyrsG4TIT9xnOlLsSSi9w/X29tCbK1yegE49RYm3tu3wF1L/B6LVMqnEWyDB26d9Ecx9zrmXCiPmIabVuLmNSg=="],
+
+    "@rollup/rollup-freebsd-x64": ["@rollup/rollup-freebsd-x64@4.46.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-pCgHFoOECwVCJ5GFq8+gR8SBKnMO+xe5UEqbemxBpCKYQddRQMgomv1104RnLSg7nNvgKy05sLsY51+OVRyiVw=="],
+
+    "@rollup/rollup-linux-arm-gnueabihf": ["@rollup/rollup-linux-arm-gnueabihf@4.46.2", "", { "os": "linux", "cpu": "arm" }, "sha512-EtP8aquZ0xQg0ETFcxUbU71MZlHaw9MChwrQzatiE8U/bvi5uv/oChExXC4mWhjiqK7azGJBqU0tt5H123SzVA=="],
+
+    "@rollup/rollup-linux-arm-musleabihf": ["@rollup/rollup-linux-arm-musleabihf@4.46.2", "", { "os": "linux", "cpu": "arm" }, "sha512-qO7F7U3u1nfxYRPM8HqFtLd+raev2K137dsV08q/LRKRLEc7RsiDWihUnrINdsWQxPR9jqZ8DIIZ1zJJAm5PjQ=="],
+
+    "@rollup/rollup-linux-arm64-gnu": ["@rollup/rollup-linux-arm64-gnu@4.46.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-3dRaqLfcOXYsfvw5xMrxAk9Lb1f395gkoBYzSFcc/scgRFptRXL9DOaDpMiehf9CO8ZDRJW2z45b6fpU5nwjng=="],
+
+    "@rollup/rollup-linux-arm64-musl": ["@rollup/rollup-linux-arm64-musl@4.46.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-fhHFTutA7SM+IrR6lIfiHskxmpmPTJUXpWIsBXpeEwNgZzZZSg/q4i6FU4J8qOGyJ0TR+wXBwx/L7Ho9z0+uDg=="],
+
+    "@rollup/rollup-linux-loongarch64-gnu": ["@rollup/rollup-linux-loongarch64-gnu@4.46.2", "", { "os": "linux", "cpu": "none" }, "sha512-i7wfGFXu8x4+FRqPymzjD+Hyav8l95UIZ773j7J7zRYc3Xsxy2wIn4x+llpunexXe6laaO72iEjeeGyUFmjKeA=="],
+
+    "@rollup/rollup-linux-ppc64-gnu": ["@rollup/rollup-linux-ppc64-gnu@4.46.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-B/l0dFcHVUnqcGZWKcWBSV2PF01YUt0Rvlurci5P+neqY/yMKchGU8ullZvIv5e8Y1C6wOn+U03mrDylP5q9Yw=="],
+
+    "@rollup/rollup-linux-riscv64-gnu": ["@rollup/rollup-linux-riscv64-gnu@4.46.2", "", { "os": "linux", "cpu": "none" }, "sha512-32k4ENb5ygtkMwPMucAb8MtV8olkPT03oiTxJbgkJa7lJ7dZMr0GCFJlyvy+K8iq7F/iuOr41ZdUHaOiqyR3iQ=="],
+
+    "@rollup/rollup-linux-riscv64-musl": ["@rollup/rollup-linux-riscv64-musl@4.46.2", "", { "os": "linux", "cpu": "none" }, "sha512-t5B2loThlFEauloaQkZg9gxV05BYeITLvLkWOkRXogP4qHXLkWSbSHKM9S6H1schf/0YGP/qNKtiISlxvfmmZw=="],
+
+    "@rollup/rollup-linux-s390x-gnu": ["@rollup/rollup-linux-s390x-gnu@4.46.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-YKjekwTEKgbB7n17gmODSmJVUIvj8CX7q5442/CK80L8nqOUbMtf8b01QkG3jOqyr1rotrAnW6B/qiHwfcuWQA=="],
+
+    "@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.46.2", "", { "os": "linux", "cpu": "x64" }, "sha512-Jj5a9RUoe5ra+MEyERkDKLwTXVu6s3aACP51nkfnK9wJTraCC8IMe3snOfALkrjTYd2G1ViE1hICj0fZ7ALBPA=="],
+
+    "@rollup/rollup-linux-x64-musl": ["@rollup/rollup-linux-x64-musl@4.46.2", "", { "os": "linux", "cpu": "x64" }, "sha512-7kX69DIrBeD7yNp4A5b81izs8BqoZkCIaxQaOpumcJ1S/kmqNFjPhDu1LHeVXv0SexfHQv5cqHsxLOjETuqDuA=="],
+
+    "@rollup/rollup-win32-arm64-msvc": ["@rollup/rollup-win32-arm64-msvc@4.46.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-wiJWMIpeaak/jsbaq2HMh/rzZxHVW1rU6coyeNNpMwk5isiPjSTx0a4YLSlYDwBH/WBvLz+EtsNqQScZTLJy3g=="],
+
+    "@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.46.2", "", { "os": "win32", "cpu": "ia32" }, "sha512-gBgaUDESVzMgWZhcyjfs9QFK16D8K6QZpwAaVNJxYDLHWayOta4ZMjGm/vsAEy3hvlS2GosVFlBlP9/Wb85DqQ=="],
+
+    "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.46.2", "", { "os": "win32", "cpu": "x64" }, "sha512-CvUo2ixeIQGtF6WvuB87XWqPQkoFAFqW+HUo/WzHwuHDvIwZCtjdWXoYCcr06iKGydiqTclC4jU/TNObC/xKZg=="],
+
+    "@shikijs/core": ["@shikijs/core@2.5.0", "", { "dependencies": { "@shikijs/engine-javascript": "2.5.0", "@shikijs/engine-oniguruma": "2.5.0", "@shikijs/types": "2.5.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.4" } }, "sha512-uu/8RExTKtavlpH7XqnVYBrfBkUc20ngXiX9NSrBhOVZYv/7XQRKUyhtkeflY5QsxC0GbJThCerruZfsUaSldg=="],
+
+    "@shikijs/engine-javascript": ["@shikijs/engine-javascript@2.5.0", "", { "dependencies": { "@shikijs/types": "2.5.0", "@shikijs/vscode-textmate": "^10.0.2", "oniguruma-to-es": "^3.1.0" } }, "sha512-VjnOpnQf8WuCEZtNUdjjwGUbtAVKuZkVQ/5cHy/tojVVRIRtlWMYVjyWhxOmIq05AlSOv72z7hRNRGVBgQOl0w=="],
+
+    "@shikijs/engine-oniguruma": ["@shikijs/engine-oniguruma@2.5.0", "", { "dependencies": { "@shikijs/types": "2.5.0", "@shikijs/vscode-textmate": "^10.0.2" } }, "sha512-pGd1wRATzbo/uatrCIILlAdFVKdxImWJGQ5rFiB5VZi2ve5xj3Ax9jny8QvkaV93btQEwR/rSz5ERFpC5mKNIw=="],
+
+    "@shikijs/langs": ["@shikijs/langs@2.5.0", "", { "dependencies": { "@shikijs/types": "2.5.0" } }, "sha512-Qfrrt5OsNH5R+5tJ/3uYBBZv3SuGmnRPejV9IlIbFH3HTGLDlkqgHymAlzklVmKBjAaVmkPkyikAV/sQ1wSL+w=="],
+
+    "@shikijs/themes": ["@shikijs/themes@2.5.0", "", { "dependencies": { "@shikijs/types": "2.5.0" } }, "sha512-wGrk+R8tJnO0VMzmUExHR+QdSaPUl/NKs+a4cQQRWyoc3YFbUzuLEi/KWK1hj+8BfHRKm2jNhhJck1dfstJpiw=="],
+
+    "@shikijs/transformers": ["@shikijs/transformers@2.5.0", "", { "dependencies": { "@shikijs/core": "2.5.0", "@shikijs/types": "2.5.0" } }, "sha512-SI494W5X60CaUwgi8u4q4m4s3YAFSxln3tzNjOSYqq54wlVgz0/NbbXEb3mdLbqMBztcmS7bVTaEd2w0qMmfeg=="],
+
+    "@shikijs/types": ["@shikijs/types@2.5.0", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-ygl5yhxki9ZLNuNpPitBWvcy9fsSKKaRuO4BAlMyagszQidxcpLAr0qiW/q43DtSIDxO6hEbtYLiFZNXO/hdGw=="],
+
+    "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
+
     "@types/bun": ["@types/bun@1.2.20", "", { "dependencies": { "bun-types": "1.2.20" } }, "sha512-dX3RGzQ8+KgmMw7CsW4xT5ITBSCrSbfHc36SNT31EOUg/LA9JWq0VDdEXDRSe1InVWpd2yLUM1FUF/kEOyTzYA=="],
+
+    "@types/d3": ["@types/d3@7.4.3", "", { "dependencies": { "@types/d3-array": "*", "@types/d3-axis": "*", "@types/d3-brush": "*", "@types/d3-chord": "*", "@types/d3-color": "*", "@types/d3-contour": "*", "@types/d3-delaunay": "*", "@types/d3-dispatch": "*", "@types/d3-drag": "*", "@types/d3-dsv": "*", "@types/d3-ease": "*", "@types/d3-fetch": "*", "@types/d3-force": "*", "@types/d3-format": "*", "@types/d3-geo": "*", "@types/d3-hierarchy": "*", "@types/d3-interpolate": "*", "@types/d3-path": "*", "@types/d3-polygon": "*", "@types/d3-quadtree": "*", "@types/d3-random": "*", "@types/d3-scale": "*", "@types/d3-scale-chromatic": "*", "@types/d3-selection": "*", "@types/d3-shape": "*", "@types/d3-time": "*", "@types/d3-time-format": "*", "@types/d3-timer": "*", "@types/d3-transition": "*", "@types/d3-zoom": "*" } }, "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww=="],
+
+    "@types/d3-array": ["@types/d3-array@3.2.1", "", {}, "sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg=="],
+
+    "@types/d3-axis": ["@types/d3-axis@3.0.6", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw=="],
+
+    "@types/d3-brush": ["@types/d3-brush@3.0.6", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A=="],
+
+    "@types/d3-chord": ["@types/d3-chord@3.0.6", "", {}, "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg=="],
+
+    "@types/d3-color": ["@types/d3-color@3.1.3", "", {}, "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="],
+
+    "@types/d3-contour": ["@types/d3-contour@3.0.6", "", { "dependencies": { "@types/d3-array": "*", "@types/geojson": "*" } }, "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg=="],
+
+    "@types/d3-delaunay": ["@types/d3-delaunay@6.0.4", "", {}, "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw=="],
+
+    "@types/d3-dispatch": ["@types/d3-dispatch@3.0.7", "", {}, "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA=="],
+
+    "@types/d3-drag": ["@types/d3-drag@3.0.7", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ=="],
+
+    "@types/d3-dsv": ["@types/d3-dsv@3.0.7", "", {}, "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g=="],
+
+    "@types/d3-ease": ["@types/d3-ease@3.0.2", "", {}, "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="],
+
+    "@types/d3-fetch": ["@types/d3-fetch@3.0.7", "", { "dependencies": { "@types/d3-dsv": "*" } }, "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA=="],
+
+    "@types/d3-force": ["@types/d3-force@3.0.10", "", {}, "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw=="],
+
+    "@types/d3-format": ["@types/d3-format@3.0.4", "", {}, "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g=="],
+
+    "@types/d3-geo": ["@types/d3-geo@3.1.0", "", { "dependencies": { "@types/geojson": "*" } }, "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ=="],
+
+    "@types/d3-hierarchy": ["@types/d3-hierarchy@3.1.7", "", {}, "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg=="],
+
+    "@types/d3-interpolate": ["@types/d3-interpolate@3.0.4", "", { "dependencies": { "@types/d3-color": "*" } }, "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA=="],
+
+    "@types/d3-path": ["@types/d3-path@3.1.1", "", {}, "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg=="],
+
+    "@types/d3-polygon": ["@types/d3-polygon@3.0.2", "", {}, "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA=="],
+
+    "@types/d3-quadtree": ["@types/d3-quadtree@3.0.6", "", {}, "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg=="],
+
+    "@types/d3-random": ["@types/d3-random@3.0.3", "", {}, "sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ=="],
+
+    "@types/d3-scale": ["@types/d3-scale@4.0.9", "", { "dependencies": { "@types/d3-time": "*" } }, "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw=="],
+
+    "@types/d3-scale-chromatic": ["@types/d3-scale-chromatic@3.1.0", "", {}, "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ=="],
+
+    "@types/d3-selection": ["@types/d3-selection@3.0.11", "", {}, "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w=="],
+
+    "@types/d3-shape": ["@types/d3-shape@3.1.7", "", { "dependencies": { "@types/d3-path": "*" } }, "sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg=="],
+
+    "@types/d3-time": ["@types/d3-time@3.0.4", "", {}, "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="],
+
+    "@types/d3-time-format": ["@types/d3-time-format@4.0.3", "", {}, "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg=="],
+
+    "@types/d3-timer": ["@types/d3-timer@3.0.2", "", {}, "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="],
+
+    "@types/d3-transition": ["@types/d3-transition@3.0.9", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg=="],
+
+    "@types/d3-zoom": ["@types/d3-zoom@3.0.8", "", { "dependencies": { "@types/d3-interpolate": "*", "@types/d3-selection": "*" } }, "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw=="],
+
+    "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
+
+    "@types/geojson": ["@types/geojson@7946.0.16", "", {}, "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg=="],
+
+    "@types/hast": ["@types/hast@3.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ=="],
+
+    "@types/linkify-it": ["@types/linkify-it@5.0.0", "", {}, "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q=="],
+
+    "@types/markdown-it": ["@types/markdown-it@14.1.2", "", { "dependencies": { "@types/linkify-it": "^5", "@types/mdurl": "^2" } }, "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog=="],
+
+    "@types/mdast": ["@types/mdast@4.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA=="],
+
+    "@types/mdurl": ["@types/mdurl@2.0.0", "", {}, "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg=="],
 
     "@types/node": ["@types/node@24.2.1", "", { "dependencies": { "undici-types": "~7.10.0" } }, "sha512-DRh5K+ka5eJic8CjH7td8QpYEV6Zo10gfRkjHCO3weqZHWDtAaSTFtl4+VMqOJ4N5jcuhZ9/l+yy8rVgw7BQeQ=="],
 
     "@types/react": ["@types/react@19.1.10", "", { "dependencies": { "csstype": "^3.0.2" } }, "sha512-EhBeSYX0Y6ye8pNebpKrwFJq7BoQ8J5SO6NlvNwwHjSj6adXJViPQrKlsyPw7hLBLvckEMO1yxeGdR82YBBlDg=="],
 
+    "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
+
+    "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
+
+    "@types/web-bluetooth": ["@types/web-bluetooth@0.0.21", "", {}, "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA=="],
+
+    "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
+
+    "@vitejs/plugin-vue": ["@vitejs/plugin-vue@5.2.4", "", { "peerDependencies": { "vite": "^5.0.0 || ^6.0.0", "vue": "^3.2.25" } }, "sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA=="],
+
+    "@vue/compiler-core": ["@vue/compiler-core@3.5.18", "", { "dependencies": { "@babel/parser": "^7.28.0", "@vue/shared": "3.5.18", "entities": "^4.5.0", "estree-walker": "^2.0.2", "source-map-js": "^1.2.1" } }, "sha512-3slwjQrrV1TO8MoXgy3aynDQ7lslj5UqDxuHnrzHtpON5CBinhWjJETciPngpin/T3OuW3tXUf86tEurusnztw=="],
+
+    "@vue/compiler-dom": ["@vue/compiler-dom@3.5.18", "", { "dependencies": { "@vue/compiler-core": "3.5.18", "@vue/shared": "3.5.18" } }, "sha512-RMbU6NTU70++B1JyVJbNbeFkK+A+Q7y9XKE2EM4NLGm2WFR8x9MbAtWxPPLdm0wUkuZv9trpwfSlL6tjdIa1+A=="],
+
+    "@vue/compiler-sfc": ["@vue/compiler-sfc@3.5.18", "", { "dependencies": { "@babel/parser": "^7.28.0", "@vue/compiler-core": "3.5.18", "@vue/compiler-dom": "3.5.18", "@vue/compiler-ssr": "3.5.18", "@vue/shared": "3.5.18", "estree-walker": "^2.0.2", "magic-string": "^0.30.17", "postcss": "^8.5.6", "source-map-js": "^1.2.1" } }, "sha512-5aBjvGqsWs+MoxswZPoTB9nSDb3dhd1x30xrrltKujlCxo48j8HGDNj3QPhF4VIS0VQDUrA1xUfp2hEa+FNyXA=="],
+
+    "@vue/compiler-ssr": ["@vue/compiler-ssr@3.5.18", "", { "dependencies": { "@vue/compiler-dom": "3.5.18", "@vue/shared": "3.5.18" } }, "sha512-xM16Ak7rSWHkM3m22NlmcdIM+K4BMyFARAfV9hYFl+SFuRzrZ3uGMNW05kA5pmeMa0X9X963Kgou7ufdbpOP9g=="],
+
+    "@vue/devtools-api": ["@vue/devtools-api@7.7.7", "", { "dependencies": { "@vue/devtools-kit": "^7.7.7" } }, "sha512-lwOnNBH2e7x1fIIbVT7yF5D+YWhqELm55/4ZKf45R9T8r9dE2AIOy8HKjfqzGsoTHFbWbr337O4E0A0QADnjBg=="],
+
+    "@vue/devtools-kit": ["@vue/devtools-kit@7.7.7", "", { "dependencies": { "@vue/devtools-shared": "^7.7.7", "birpc": "^2.3.0", "hookable": "^5.5.3", "mitt": "^3.0.1", "perfect-debounce": "^1.0.0", "speakingurl": "^14.0.1", "superjson": "^2.2.2" } }, "sha512-wgoZtxcTta65cnZ1Q6MbAfePVFxfM+gq0saaeytoph7nEa7yMXoi6sCPy4ufO111B9msnw0VOWjPEFCXuAKRHA=="],
+
+    "@vue/devtools-shared": ["@vue/devtools-shared@7.7.7", "", { "dependencies": { "rfdc": "^1.4.1" } }, "sha512-+udSj47aRl5aKb0memBvcUG9koarqnxNM5yjuREvqwK6T3ap4mn3Zqqc17QrBFTqSMjr3HK1cvStEZpMDpfdyw=="],
+
+    "@vue/reactivity": ["@vue/reactivity@3.5.18", "", { "dependencies": { "@vue/shared": "3.5.18" } }, "sha512-x0vPO5Imw+3sChLM5Y+B6G1zPjwdOri9e8V21NnTnlEvkxatHEH5B5KEAJcjuzQ7BsjGrKtfzuQ5eQwXh8HXBg=="],
+
+    "@vue/runtime-core": ["@vue/runtime-core@3.5.18", "", { "dependencies": { "@vue/reactivity": "3.5.18", "@vue/shared": "3.5.18" } }, "sha512-DUpHa1HpeOQEt6+3nheUfqVXRog2kivkXHUhoqJiKR33SO4x+a5uNOMkV487WPerQkL0vUuRvq/7JhRgLW3S+w=="],
+
+    "@vue/runtime-dom": ["@vue/runtime-dom@3.5.18", "", { "dependencies": { "@vue/reactivity": "3.5.18", "@vue/runtime-core": "3.5.18", "@vue/shared": "3.5.18", "csstype": "^3.1.3" } }, "sha512-YwDj71iV05j4RnzZnZtGaXwPoUWeRsqinblgVJwR8XTXYZ9D5PbahHQgsbmzUvCWNF6x7siQ89HgnX5eWkr3mw=="],
+
+    "@vue/server-renderer": ["@vue/server-renderer@3.5.18", "", { "dependencies": { "@vue/compiler-ssr": "3.5.18", "@vue/shared": "3.5.18" }, "peerDependencies": { "vue": "3.5.18" } }, "sha512-PvIHLUoWgSbDG7zLHqSqaCoZvHi6NNmfVFOqO+OnwvqMz/tqQr3FuGWS8ufluNddk7ZLBJYMrjcw1c6XzR12mA=="],
+
+    "@vue/shared": ["@vue/shared@3.5.18", "", {}, "sha512-cZy8Dq+uuIXbxCZpuLd2GJdeSO/lIzIspC2WtkqIpje5QyFbvLaI5wZtdUjLHjGZrlVX6GilejatWwVYYRc8tA=="],
+
+    "@vueuse/core": ["@vueuse/core@12.8.2", "", { "dependencies": { "@types/web-bluetooth": "^0.0.21", "@vueuse/metadata": "12.8.2", "@vueuse/shared": "12.8.2", "vue": "^3.5.13" } }, "sha512-HbvCmZdzAu3VGi/pWYm5Ut+Kd9mn1ZHnn4L5G8kOQTPs/IwIAmJoBrmYk2ckLArgMXZj0AW3n5CAejLUO+PhdQ=="],
+
+    "@vueuse/integrations": ["@vueuse/integrations@12.8.2", "", { "dependencies": { "@vueuse/core": "12.8.2", "@vueuse/shared": "12.8.2", "vue": "^3.5.13" }, "peerDependencies": { "async-validator": "^4", "axios": "^1", "change-case": "^5", "drauu": "^0.4", "focus-trap": "^7", "fuse.js": "^7", "idb-keyval": "^6", "jwt-decode": "^4", "nprogress": "^0.2", "qrcode": "^1.5", "sortablejs": "^1", "universal-cookie": "^7" }, "optionalPeers": ["async-validator", "axios", "change-case", "drauu", "focus-trap", "fuse.js", "idb-keyval", "jwt-decode", "nprogress", "qrcode", "sortablejs", "universal-cookie"] }, "sha512-fbGYivgK5uBTRt7p5F3zy6VrETlV9RtZjBqd1/HxGdjdckBgBM4ugP8LHpjolqTj14TXTxSK1ZfgPbHYyGuH7g=="],
+
+    "@vueuse/metadata": ["@vueuse/metadata@12.8.2", "", {}, "sha512-rAyLGEuoBJ/Il5AmFHiziCPdQzRt88VxR+Y/A/QhJ1EWtWqPBBAxTAFaSkviwEuOEZNtW8pvkPgoCZQ+HxqW1A=="],
+
+    "@vueuse/shared": ["@vueuse/shared@12.8.2", "", { "dependencies": { "vue": "^3.5.13" } }, "sha512-dznP38YzxZoNloI0qpEfpkms8knDtaoQ6Y/sfS0L7Yki4zh40LFHEhur0odJC6xTHG5dxWVPiUWBXn+wCG2s5w=="],
+
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 
+    "acorn": ["acorn@8.15.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="],
+
     "ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
+
+    "algoliasearch": ["algoliasearch@5.35.0", "", { "dependencies": { "@algolia/abtesting": "1.1.0", "@algolia/client-abtesting": "5.35.0", "@algolia/client-analytics": "5.35.0", "@algolia/client-common": "5.35.0", "@algolia/client-insights": "5.35.0", "@algolia/client-personalization": "5.35.0", "@algolia/client-query-suggestions": "5.35.0", "@algolia/client-search": "5.35.0", "@algolia/ingestion": "1.35.0", "@algolia/monitoring": "1.35.0", "@algolia/recommend": "5.35.0", "@algolia/requester-browser-xhr": "5.35.0", "@algolia/requester-fetch": "5.35.0", "@algolia/requester-node-http": "5.35.0" } }, "sha512-Y+moNhsqgLmvJdgTsO4GZNgsaDWv8AOGAaPeIeHKlDn/XunoAqYbA+XNpBd1dW8GOXAUDyxC9Rxc7AV4kpFcIg=="],
+
+    "birpc": ["birpc@2.5.0", "", {}, "sha512-VSWO/W6nNQdyP520F1mhf+Lc2f8pjGQOtoHHm7Ze8Go1kX7akpVIrtTa0fn+HB0QJEDVacl6aO08YE0PgXfdnQ=="],
 
     "body-parser": ["body-parser@2.2.0", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.0", "http-errors": "^2.0.0", "iconv-lite": "^0.6.3", "on-finished": "^2.4.1", "qs": "^6.14.0", "raw-body": "^3.0.0", "type-is": "^2.0.0" } }, "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg=="],
 
@@ -46,6 +357,22 @@
 
     "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
 
+    "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
+
+    "character-entities-html4": ["character-entities-html4@2.1.0", "", {}, "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA=="],
+
+    "character-entities-legacy": ["character-entities-legacy@3.0.0", "", {}, "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ=="],
+
+    "chevrotain": ["chevrotain@11.0.3", "", { "dependencies": { "@chevrotain/cst-dts-gen": "11.0.3", "@chevrotain/gast": "11.0.3", "@chevrotain/regexp-to-ast": "11.0.3", "@chevrotain/types": "11.0.3", "@chevrotain/utils": "11.0.3", "lodash-es": "4.17.21" } }, "sha512-ci2iJH6LeIkvP9eJW6gpueU8cnZhv85ELY8w8WiFtNjMHA5ad6pQLaJo9mEly/9qUyCpvqX8/POVUTf18/HFdw=="],
+
+    "chevrotain-allstar": ["chevrotain-allstar@0.3.1", "", { "dependencies": { "lodash-es": "^4.17.21" }, "peerDependencies": { "chevrotain": "^11.0.0" } }, "sha512-b7g+y9A0v4mxCW1qUhf3BSVPg+/NvGErk/dOkrDaHA0nQIQGAtrOjlX//9OQtRlSCy+x9rfB5N8yC71lH1nvMw=="],
+
+    "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
+
+    "commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
+
+    "confbox": ["confbox@0.2.2", "", {}, "sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ=="],
+
     "content-disposition": ["content-disposition@1.0.0", "", { "dependencies": { "safe-buffer": "5.2.1" } }, "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg=="],
 
     "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
@@ -54,11 +381,89 @@
 
     "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
 
+    "copy-anything": ["copy-anything@3.0.5", "", { "dependencies": { "is-what": "^4.1.8" } }, "sha512-yCEafptTtb4bk7GLEQoM8KVJpxAfdBJYaXyzQEgQQQgYrZiDp8SJmGKlYza6CYjEDNstAdNdKA3UuoULlEbS6w=="],
+
     "cors": ["cors@2.8.5", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g=="],
+
+    "cose-base": ["cose-base@1.0.3", "", { "dependencies": { "layout-base": "^1.0.0" } }, "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
     "csstype": ["csstype@3.1.3", "", {}, "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="],
+
+    "cytoscape": ["cytoscape@3.33.1", "", {}, "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ=="],
+
+    "cytoscape-cose-bilkent": ["cytoscape-cose-bilkent@4.1.0", "", { "dependencies": { "cose-base": "^1.0.0" }, "peerDependencies": { "cytoscape": "^3.2.0" } }, "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ=="],
+
+    "cytoscape-fcose": ["cytoscape-fcose@2.2.0", "", { "dependencies": { "cose-base": "^2.2.0" }, "peerDependencies": { "cytoscape": "^3.2.0" } }, "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ=="],
+
+    "d3": ["d3@7.9.0", "", { "dependencies": { "d3-array": "3", "d3-axis": "3", "d3-brush": "3", "d3-chord": "3", "d3-color": "3", "d3-contour": "4", "d3-delaunay": "6", "d3-dispatch": "3", "d3-drag": "3", "d3-dsv": "3", "d3-ease": "3", "d3-fetch": "3", "d3-force": "3", "d3-format": "3", "d3-geo": "3", "d3-hierarchy": "3", "d3-interpolate": "3", "d3-path": "3", "d3-polygon": "3", "d3-quadtree": "3", "d3-random": "3", "d3-scale": "4", "d3-scale-chromatic": "3", "d3-selection": "3", "d3-shape": "3", "d3-time": "3", "d3-time-format": "4", "d3-timer": "3", "d3-transition": "3", "d3-zoom": "3" } }, "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA=="],
+
+    "d3-array": ["d3-array@3.2.4", "", { "dependencies": { "internmap": "1 - 2" } }, "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg=="],
+
+    "d3-axis": ["d3-axis@3.0.0", "", {}, "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw=="],
+
+    "d3-brush": ["d3-brush@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-drag": "2 - 3", "d3-interpolate": "1 - 3", "d3-selection": "3", "d3-transition": "3" } }, "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ=="],
+
+    "d3-chord": ["d3-chord@3.0.1", "", { "dependencies": { "d3-path": "1 - 3" } }, "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g=="],
+
+    "d3-color": ["d3-color@3.1.0", "", {}, "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="],
+
+    "d3-contour": ["d3-contour@4.0.2", "", { "dependencies": { "d3-array": "^3.2.0" } }, "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA=="],
+
+    "d3-delaunay": ["d3-delaunay@6.0.4", "", { "dependencies": { "delaunator": "5" } }, "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A=="],
+
+    "d3-dispatch": ["d3-dispatch@3.0.1", "", {}, "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg=="],
+
+    "d3-drag": ["d3-drag@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-selection": "3" } }, "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg=="],
+
+    "d3-dsv": ["d3-dsv@3.0.1", "", { "dependencies": { "commander": "7", "iconv-lite": "0.6", "rw": "1" }, "bin": { "csv2json": "bin/dsv2json.js", "csv2tsv": "bin/dsv2dsv.js", "dsv2dsv": "bin/dsv2dsv.js", "dsv2json": "bin/dsv2json.js", "json2csv": "bin/json2dsv.js", "json2dsv": "bin/json2dsv.js", "json2tsv": "bin/json2dsv.js", "tsv2csv": "bin/dsv2dsv.js", "tsv2json": "bin/dsv2json.js" } }, "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q=="],
+
+    "d3-ease": ["d3-ease@3.0.1", "", {}, "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="],
+
+    "d3-fetch": ["d3-fetch@3.0.1", "", { "dependencies": { "d3-dsv": "1 - 3" } }, "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw=="],
+
+    "d3-force": ["d3-force@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-quadtree": "1 - 3", "d3-timer": "1 - 3" } }, "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg=="],
+
+    "d3-format": ["d3-format@3.1.0", "", {}, "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA=="],
+
+    "d3-geo": ["d3-geo@3.1.1", "", { "dependencies": { "d3-array": "2.5.0 - 3" } }, "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q=="],
+
+    "d3-hierarchy": ["d3-hierarchy@3.1.2", "", {}, "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA=="],
+
+    "d3-interpolate": ["d3-interpolate@3.0.1", "", { "dependencies": { "d3-color": "1 - 3" } }, "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g=="],
+
+    "d3-path": ["d3-path@3.1.0", "", {}, "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ=="],
+
+    "d3-polygon": ["d3-polygon@3.0.1", "", {}, "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg=="],
+
+    "d3-quadtree": ["d3-quadtree@3.0.1", "", {}, "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw=="],
+
+    "d3-random": ["d3-random@3.0.1", "", {}, "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ=="],
+
+    "d3-sankey": ["d3-sankey@0.12.3", "", { "dependencies": { "d3-array": "1 - 2", "d3-shape": "^1.2.0" } }, "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ=="],
+
+    "d3-scale": ["d3-scale@4.0.2", "", { "dependencies": { "d3-array": "2.10.0 - 3", "d3-format": "1 - 3", "d3-interpolate": "1.2.0 - 3", "d3-time": "2.1.1 - 3", "d3-time-format": "2 - 4" } }, "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ=="],
+
+    "d3-scale-chromatic": ["d3-scale-chromatic@3.1.0", "", { "dependencies": { "d3-color": "1 - 3", "d3-interpolate": "1 - 3" } }, "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ=="],
+
+    "d3-selection": ["d3-selection@3.0.0", "", {}, "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ=="],
+
+    "d3-shape": ["d3-shape@3.2.0", "", { "dependencies": { "d3-path": "^3.1.0" } }, "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA=="],
+
+    "d3-time": ["d3-time@3.1.0", "", { "dependencies": { "d3-array": "2 - 3" } }, "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q=="],
+
+    "d3-time-format": ["d3-time-format@4.1.0", "", { "dependencies": { "d3-time": "1 - 3" } }, "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg=="],
+
+    "d3-timer": ["d3-timer@3.0.1", "", {}, "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="],
+
+    "d3-transition": ["d3-transition@3.0.1", "", { "dependencies": { "d3-color": "1 - 3", "d3-dispatch": "1 - 3", "d3-ease": "1 - 3", "d3-interpolate": "1 - 3", "d3-timer": "1 - 3" }, "peerDependencies": { "d3-selection": "2 - 3" } }, "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w=="],
+
+    "d3-zoom": ["d3-zoom@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-drag": "2 - 3", "d3-interpolate": "1 - 3", "d3-selection": "2 - 3", "d3-transition": "2 - 3" } }, "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw=="],
+
+    "dagre-d3-es": ["dagre-d3-es@7.0.11", "", { "dependencies": { "d3": "^7.9.0", "lodash-es": "^4.17.21" } }, "sha512-tvlJLyQf834SylNKax8Wkzco/1ias1OPw8DcUMDE7oUIoSEW25riQVuiu/0OWEFqT0cxHT3Pa9/D82Jr47IONw=="],
+
+    "dayjs": ["dayjs@1.11.13", "", {}, "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg=="],
 
     "debug": ["debug@4.4.1", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ=="],
 
@@ -68,13 +473,25 @@
 
     "define-lazy-prop": ["define-lazy-prop@3.0.0", "", {}, "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg=="],
 
+    "delaunator": ["delaunator@5.0.1", "", { "dependencies": { "robust-predicates": "^3.0.2" } }, "sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw=="],
+
     "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
+
+    "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
+
+    "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
+
+    "dompurify": ["dompurify@3.2.6", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ=="],
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
     "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
 
+    "emoji-regex-xs": ["emoji-regex-xs@1.0.0", "", {}, "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg=="],
+
     "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
+
+    "entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
     "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
 
@@ -82,7 +499,11 @@
 
     "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
 
+    "esbuild": ["esbuild@0.21.5", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.21.5", "@esbuild/android-arm": "0.21.5", "@esbuild/android-arm64": "0.21.5", "@esbuild/android-x64": "0.21.5", "@esbuild/darwin-arm64": "0.21.5", "@esbuild/darwin-x64": "0.21.5", "@esbuild/freebsd-arm64": "0.21.5", "@esbuild/freebsd-x64": "0.21.5", "@esbuild/linux-arm": "0.21.5", "@esbuild/linux-arm64": "0.21.5", "@esbuild/linux-ia32": "0.21.5", "@esbuild/linux-loong64": "0.21.5", "@esbuild/linux-mips64el": "0.21.5", "@esbuild/linux-ppc64": "0.21.5", "@esbuild/linux-riscv64": "0.21.5", "@esbuild/linux-s390x": "0.21.5", "@esbuild/linux-x64": "0.21.5", "@esbuild/netbsd-x64": "0.21.5", "@esbuild/openbsd-x64": "0.21.5", "@esbuild/sunos-x64": "0.21.5", "@esbuild/win32-arm64": "0.21.5", "@esbuild/win32-ia32": "0.21.5", "@esbuild/win32-x64": "0.21.5" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw=="],
+
     "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
+
+    "estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
     "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
 
@@ -94,15 +515,21 @@
 
     "express-rate-limit": ["express-rate-limit@7.5.1", "", { "peerDependencies": { "express": ">= 4.11" } }, "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw=="],
 
+    "exsolve": ["exsolve@1.0.7", "", {}, "sha512-VO5fQUzZtI6C+vx4w/4BWJpg3s/5l+6pRQEHzFRM8WFi4XffSP1Z+4qi7GbjWbvRQEbdIco5mIMq+zX4rPuLrw=="],
+
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
     "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="],
 
     "finalhandler": ["finalhandler@2.1.0", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q=="],
 
+    "focus-trap": ["focus-trap@7.6.5", "", { "dependencies": { "tabbable": "^6.2.0" } }, "sha512-7Ke1jyybbbPZyZXFxEftUtxFGLMpE2n6A+z//m4CRDlj0hW+o3iYSmh8nFlYMurOiJVDmJRilUQtJr08KfIxlg=="],
+
     "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
 
     "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
@@ -110,17 +537,31 @@
 
     "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
 
+    "globals": ["globals@15.15.0", "", {}, "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg=="],
+
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "hachure-fill": ["hachure-fill@0.5.2", "", {}, "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg=="],
 
     "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
 
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
+
+    "hast-util-to-html": ["hast-util-to-html@9.0.5", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "ccount": "^2.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-whitespace": "^3.0.0", "html-void-elements": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "stringify-entities": "^4.0.0", "zwitch": "^2.0.4" } }, "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw=="],
+
+    "hast-util-whitespace": ["hast-util-whitespace@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw=="],
+
+    "hookable": ["hookable@5.5.3", "", {}, "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ=="],
+
+    "html-void-elements": ["html-void-elements@3.0.0", "", {}, "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="],
 
     "http-errors": ["http-errors@2.0.0", "", { "dependencies": { "depd": "2.0.0", "inherits": "2.0.4", "setprototypeof": "1.2.0", "statuses": "2.0.1", "toidentifier": "1.0.1" } }, "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ=="],
 
     "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "internmap": ["internmap@2.0.3", "", {}, "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="],
 
     "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
 
@@ -130,27 +571,73 @@
 
     "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
 
+    "is-what": ["is-what@4.1.16", "", {}, "sha512-ZhMwEosbFJkA0YhFnNDgTM4ZxDRsS6HqTo7qsZM08fehyRYIYa0yHu5R6mgo1n/8MgaPBXiPimPD77baVFYg+A=="],
+
     "is-wsl": ["is-wsl@3.1.0", "", { "dependencies": { "is-inside-container": "^1.0.0" } }, "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw=="],
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
     "json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 
+    "katex": ["katex@0.16.22", "", { "dependencies": { "commander": "^8.3.0" }, "bin": { "katex": "cli.js" } }, "sha512-XCHRdUw4lf3SKBaJe4EvgqIuWwkPSo9XoeO8GjQW94Bp7TWv9hNhzZjZ+OH9yf1UmLygb7DIT5GSFQiyt16zYg=="],
+
+    "khroma": ["khroma@2.1.0", "", {}, "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="],
+
+    "kolorist": ["kolorist@1.8.0", "", {}, "sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ=="],
+
+    "langium": ["langium@3.3.1", "", { "dependencies": { "chevrotain": "~11.0.3", "chevrotain-allstar": "~0.3.0", "vscode-languageserver": "~9.0.1", "vscode-languageserver-textdocument": "~1.0.11", "vscode-uri": "~3.0.8" } }, "sha512-QJv/h939gDpvT+9SiLVlY7tZC3xB2qK57v0J04Sh9wpMb6MP1q8gB21L3WIo8T5P1MSMg3Ep14L7KkDCFG3y4w=="],
+
+    "layout-base": ["layout-base@1.0.2", "", {}, "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg=="],
+
+    "local-pkg": ["local-pkg@1.1.1", "", { "dependencies": { "mlly": "^1.7.4", "pkg-types": "^2.0.1", "quansync": "^0.2.8" } }, "sha512-WunYko2W1NcdfAFpuLUoucsgULmgDBRkdxHxWQ7mK0cQqwPiy8E1enjuRBrhLtZkB5iScJ1XIPdhVEFK8aOLSg=="],
+
+    "lodash-es": ["lodash-es@4.17.21", "", {}, "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="],
+
+    "magic-string": ["magic-string@0.30.17", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0" } }, "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA=="],
+
+    "mark.js": ["mark.js@8.11.1", "", {}, "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ=="],
+
+    "marked": ["marked@16.1.2", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-rNQt5EvRinalby7zJZu/mB+BvaAY2oz3wCuCjt1RDrWNpS1Pdf9xqMOeC9Hm5adBdcV/3XZPJpG58eT+WBc0XQ=="],
+
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "mdast-util-to-hast": ["mdast-util-to-hast@13.2.0", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "@ungap/structured-clone": "^1.0.0", "devlop": "^1.0.0", "micromark-util-sanitize-uri": "^2.0.0", "trim-lines": "^3.0.0", "unist-util-position": "^5.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-QGYKEuUsYT9ykKBCMOEDLsU5JRObWQusAolFMeko/tYPufNkRffBAQjIE+99jbA87xv6FgmjLtwjh9wBWajwAA=="],
 
     "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
 
     "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
 
+    "mermaid": ["mermaid@11.9.0", "", { "dependencies": { "@braintree/sanitize-url": "^7.0.4", "@iconify/utils": "^2.1.33", "@mermaid-js/parser": "^0.6.2", "@types/d3": "^7.4.3", "cytoscape": "^3.29.3", "cytoscape-cose-bilkent": "^4.1.0", "cytoscape-fcose": "^2.2.0", "d3": "^7.9.0", "d3-sankey": "^0.12.3", "dagre-d3-es": "7.0.11", "dayjs": "^1.11.13", "dompurify": "^3.2.5", "katex": "^0.16.22", "khroma": "^2.1.0", "lodash-es": "^4.17.21", "marked": "^16.0.0", "roughjs": "^4.6.6", "stylis": "^4.3.6", "ts-dedent": "^2.2.0", "uuid": "^11.1.0" } }, "sha512-YdPXn9slEwO0omQfQIsW6vS84weVQftIyyTGAZCwM//MGhPzL1+l6vO6bkf0wnP4tHigH1alZ5Ooy3HXI2gOag=="],
+
+    "micromark-util-character": ["micromark-util-character@2.1.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q=="],
+
+    "micromark-util-encode": ["micromark-util-encode@2.0.1", "", {}, "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw=="],
+
+    "micromark-util-sanitize-uri": ["micromark-util-sanitize-uri@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-symbol": "^2.0.0" } }, "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ=="],
+
+    "micromark-util-symbol": ["micromark-util-symbol@2.0.1", "", {}, "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q=="],
+
+    "micromark-util-types": ["micromark-util-types@2.0.2", "", {}, "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA=="],
+
     "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
     "mime-types": ["mime-types@3.0.1", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA=="],
+
+    "minisearch": ["minisearch@7.1.2", "", {}, "sha512-R1Pd9eF+MD5JYDDSPAp/q1ougKglm14uEkPMvQ/05RGmx6G9wvmLTrTI/Q5iPNJLYqNdsDQ7qTGIcNWR+FrHmA=="],
+
+    "mitt": ["mitt@3.0.1", "", {}, "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw=="],
+
+    "mlly": ["mlly@1.7.4", "", { "dependencies": { "acorn": "^8.14.0", "pathe": "^2.0.1", "pkg-types": "^1.3.0", "ufo": "^1.5.4" } }, "sha512-qmdSIPC4bDJXgZTCR7XosJiNKySV7O215tsPtDN9iEO/7q/76b/ijtgRu/+epFXSJhijtTCCGp3DWS549P3xKw=="],
 
     "mri": ["mri@1.2.0", "", {}, "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
+    "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
+
     "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+
+    "non-layered-tidy-tree-layout": ["non-layered-tidy-tree-layout@2.0.2", "", {}, "sha512-gkXMxRzUH+PB0ax9dUN0yYF0S25BqeAYqhgMaLUFmpXLEk7Fcu8f4emJuOAY0V8kjDICxROIKsTAKsV/v355xw=="],
 
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
@@ -160,21 +647,41 @@
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
+    "oniguruma-to-es": ["oniguruma-to-es@3.1.1", "", { "dependencies": { "emoji-regex-xs": "^1.0.0", "regex": "^6.0.1", "regex-recursion": "^6.0.2" } }, "sha512-bUH8SDvPkH3ho3dvwJwfonjlQ4R80vjyvrU8YpxuROddv55vAEJrTuCuCVUhhsHbtlD9tGGbaNApGQckXhS8iQ=="],
+
     "open": ["open@10.2.0", "", { "dependencies": { "default-browser": "^5.2.1", "define-lazy-prop": "^3.0.0", "is-inside-container": "^1.0.0", "wsl-utils": "^0.1.0" } }, "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA=="],
 
     "package-manager-detector": ["package-manager-detector@1.3.0", "", {}, "sha512-ZsEbbZORsyHuO00lY1kV3/t72yp6Ysay6Pd17ZAlNGuGwmWDLCJxFpRs0IzfXfj1o4icJOkUEioexFHzyPurSQ=="],
 
     "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
 
+    "path-data-parser": ["path-data-parser@0.1.0", "", {}, "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w=="],
+
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
     "path-to-regexp": ["path-to-regexp@8.2.0", "", {}, "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ=="],
+
+    "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
+    "perfect-debounce": ["perfect-debounce@1.0.0", "", {}, "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "pkce-challenge": ["pkce-challenge@5.0.0", "", {}, "sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ=="],
 
+    "pkg-types": ["pkg-types@2.2.0", "", { "dependencies": { "confbox": "^0.2.2", "exsolve": "^1.0.7", "pathe": "^2.0.3" } }, "sha512-2SM/GZGAEkPp3KWORxQZns4M+WSeXbC2HEvmOIJe3Cmiv6ieAJvdVhDldtHqM5J1Y7MrR1XhkBT/rMlhh9FdqQ=="],
+
+    "points-on-curve": ["points-on-curve@0.2.0", "", {}, "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A=="],
+
+    "points-on-path": ["points-on-path@0.2.1", "", { "dependencies": { "path-data-parser": "0.1.0", "points-on-curve": "0.2.0" } }, "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g=="],
+
+    "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
+
+    "preact": ["preact@10.27.0", "", {}, "sha512-/DTYoB6mwwgPytiqQTh/7SFRL98ZdiD8Sk8zIUVOxtwq4oWcwrcd1uno9fE/zZmUaUrFNYzbH14CPebOz9tZQw=="],
+
     "prettier": ["prettier@3.6.2", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ=="],
+
+    "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
 
     "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
 
@@ -184,19 +691,39 @@
 
     "qs": ["qs@6.14.0", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w=="],
 
+    "quansync": ["quansync@0.2.11", "", {}, "sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA=="],
+
     "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
 
     "raw-body": ["raw-body@3.0.0", "", { "dependencies": { "bytes": "3.1.2", "http-errors": "2.0.0", "iconv-lite": "0.6.3", "unpipe": "1.0.0" } }, "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g=="],
 
+    "regex": ["regex@6.0.1", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-uorlqlzAKjKQZ5P+kTJr3eeJGSVroLKoHmquUj4zHWuR+hEyNqlXsSKlYYF5F4NI6nl7tWCs0apKJ0lmfsXAPA=="],
+
+    "regex-recursion": ["regex-recursion@6.0.2", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg=="],
+
+    "regex-utilities": ["regex-utilities@2.3.0", "", {}, "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng=="],
+
+    "rfdc": ["rfdc@1.4.1", "", {}, "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA=="],
+
+    "robust-predicates": ["robust-predicates@3.0.2", "", {}, "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg=="],
+
+    "rollup": ["rollup@4.46.2", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.46.2", "@rollup/rollup-android-arm64": "4.46.2", "@rollup/rollup-darwin-arm64": "4.46.2", "@rollup/rollup-darwin-x64": "4.46.2", "@rollup/rollup-freebsd-arm64": "4.46.2", "@rollup/rollup-freebsd-x64": "4.46.2", "@rollup/rollup-linux-arm-gnueabihf": "4.46.2", "@rollup/rollup-linux-arm-musleabihf": "4.46.2", "@rollup/rollup-linux-arm64-gnu": "4.46.2", "@rollup/rollup-linux-arm64-musl": "4.46.2", "@rollup/rollup-linux-loongarch64-gnu": "4.46.2", "@rollup/rollup-linux-ppc64-gnu": "4.46.2", "@rollup/rollup-linux-riscv64-gnu": "4.46.2", "@rollup/rollup-linux-riscv64-musl": "4.46.2", "@rollup/rollup-linux-s390x-gnu": "4.46.2", "@rollup/rollup-linux-x64-gnu": "4.46.2", "@rollup/rollup-linux-x64-musl": "4.46.2", "@rollup/rollup-win32-arm64-msvc": "4.46.2", "@rollup/rollup-win32-ia32-msvc": "4.46.2", "@rollup/rollup-win32-x64-msvc": "4.46.2", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-WMmLFI+Boh6xbop+OAGo9cQ3OgX9MIg7xOQjn+pTCwOkk+FNDAeAemXkJ3HzDJrVXleLOFVa1ipuc1AmEx1Dwg=="],
+
+    "roughjs": ["roughjs@4.6.6", "", { "dependencies": { "hachure-fill": "^0.5.2", "path-data-parser": "^0.1.0", "points-on-curve": "^0.2.0", "points-on-path": "^0.2.1" } }, "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ=="],
+
     "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
 
     "run-applescript": ["run-applescript@7.0.0", "", {}, "sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A=="],
+
+    "rw": ["rw@1.3.3", "", {}, "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="],
 
     "sade": ["sade@1.8.1", "", { "dependencies": { "mri": "^1.1.0" } }, "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A=="],
 
     "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "search-insights": ["search-insights@2.17.3", "", {}, "sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ=="],
 
     "send": ["send@1.2.0", "", { "dependencies": { "debug": "^4.3.5", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.0", "mime-types": "^3.0.1", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.1" } }, "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw=="],
 
@@ -208,6 +735,8 @@
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
 
+    "shiki": ["shiki@2.5.0", "", { "dependencies": { "@shikijs/core": "2.5.0", "@shikijs/engine-javascript": "2.5.0", "@shikijs/engine-oniguruma": "2.5.0", "@shikijs/langs": "2.5.0", "@shikijs/themes": "2.5.0", "@shikijs/types": "2.5.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-mI//trrsaiCIPsja5CNfsyNOqgAZUb6VpJA+340toL42UpzQlXpwRV9nch69X6gaUxrr9kaOOa6e3y3uAkGFxQ=="],
+
     "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
 
     "side-channel-list": ["side-channel-list@1.0.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3" } }, "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA=="],
@@ -216,21 +745,79 @@
 
     "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
 
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
+
+    "speakingurl": ["speakingurl@14.0.1", "", {}, "sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ=="],
+
     "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
+    "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
+
+    "stylis": ["stylis@4.3.6", "", {}, "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ=="],
+
+    "superjson": ["superjson@2.2.2", "", { "dependencies": { "copy-anything": "^3.0.2" } }, "sha512-5JRxVqC8I8NuOUjzBbvVJAKNM8qoVuH0O77h4WInc/qC2q5IreqKxYwgkga3PfA22OayK2ikceb/B26dztPl+Q=="],
+
+    "tabbable": ["tabbable@6.2.0", "", {}, "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew=="],
+
+    "tinyexec": ["tinyexec@1.0.1", "", {}, "sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw=="],
+
     "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
+    "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
+
+    "ts-dedent": ["ts-dedent@2.2.0", "", {}, "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ=="],
 
     "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
 
     "typescript": ["typescript@5.9.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A=="],
 
+    "ufo": ["ufo@1.6.1", "", {}, "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA=="],
+
     "undici-types": ["undici-types@7.10.0", "", {}, "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag=="],
+
+    "unist-util-is": ["unist-util-is@6.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw=="],
+
+    "unist-util-position": ["unist-util-position@5.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA=="],
+
+    "unist-util-stringify-position": ["unist-util-stringify-position@4.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ=="],
+
+    "unist-util-visit": ["unist-util-visit@5.0.0", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg=="],
+
+    "unist-util-visit-parents": ["unist-util-visit-parents@6.0.1", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0" } }, "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw=="],
 
     "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
 
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
 
+    "uuid": ["uuid@11.1.0", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="],
+
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
+
+    "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
+
+    "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
+
+    "vite": ["vite@5.4.19", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA=="],
+
+    "vitepress": ["vitepress@1.6.4", "", { "dependencies": { "@docsearch/css": "3.8.2", "@docsearch/js": "3.8.2", "@iconify-json/simple-icons": "^1.2.21", "@shikijs/core": "^2.1.0", "@shikijs/transformers": "^2.1.0", "@shikijs/types": "^2.1.0", "@types/markdown-it": "^14.1.2", "@vitejs/plugin-vue": "^5.2.1", "@vue/devtools-api": "^7.7.0", "@vue/shared": "^3.5.13", "@vueuse/core": "^12.4.0", "@vueuse/integrations": "^12.4.0", "focus-trap": "^7.6.4", "mark.js": "8.11.1", "minisearch": "^7.1.1", "shiki": "^2.1.0", "vite": "^5.4.14", "vue": "^3.5.13" }, "peerDependencies": { "markdown-it-mathjax3": "^4", "postcss": "^8" }, "optionalPeers": ["markdown-it-mathjax3", "postcss"], "bin": { "vitepress": "bin/vitepress.js" } }, "sha512-+2ym1/+0VVrbhNyRoFFesVvBvHAVMZMK0rw60E3X/5349M1GuVdKeazuksqopEdvkKwKGs21Q729jX81/bkBJg=="],
+
+    "vitepress-plugin-mermaid": ["vitepress-plugin-mermaid@2.0.17", "", { "optionalDependencies": { "@mermaid-js/mermaid-mindmap": "^9.3.0" }, "peerDependencies": { "mermaid": "10 || 11", "vitepress": "^1.0.0 || ^1.0.0-alpha" } }, "sha512-IUzYpwf61GC6k0XzfmAmNrLvMi9TRrVRMsUyCA8KNXhg/mQ1VqWnO0/tBVPiX5UoKF1mDUwqn5QV4qAJl6JnUg=="],
+
+    "vscode-jsonrpc": ["vscode-jsonrpc@8.2.0", "", {}, "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA=="],
+
+    "vscode-languageserver": ["vscode-languageserver@9.0.1", "", { "dependencies": { "vscode-languageserver-protocol": "3.17.5" }, "bin": { "installServerIntoExtension": "bin/installServerIntoExtension" } }, "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g=="],
+
+    "vscode-languageserver-protocol": ["vscode-languageserver-protocol@3.17.5", "", { "dependencies": { "vscode-jsonrpc": "8.2.0", "vscode-languageserver-types": "3.17.5" } }, "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg=="],
+
+    "vscode-languageserver-textdocument": ["vscode-languageserver-textdocument@1.0.12", "", {}, "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA=="],
+
+    "vscode-languageserver-types": ["vscode-languageserver-types@3.17.5", "", {}, "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg=="],
+
+    "vscode-uri": ["vscode-uri@3.0.8", "", {}, "sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw=="],
+
+    "vue": ["vue@3.5.18", "", { "dependencies": { "@vue/compiler-dom": "3.5.18", "@vue/compiler-sfc": "3.5.18", "@vue/runtime-dom": "3.5.18", "@vue/server-renderer": "3.5.18", "@vue/shared": "3.5.18" }, "peerDependencies": { "typescript": "*" }, "optionalPeers": ["typescript"] }, "sha512-7W4Y4ZbMiQ3SEo+m9lnoNpV9xG7QVMLa+/0RFwwiAVkeYoyGXqWE85jabU4pllJNUzqfLShJ5YLptewhCWUgNA=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
@@ -242,6 +829,28 @@
 
     "zod-to-json-schema": ["zod-to-json-schema@3.24.6", "", { "peerDependencies": { "zod": "^3.24.1" } }, "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg=="],
 
+    "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
+
+    "@mermaid-js/mermaid-mindmap/@braintree/sanitize-url": ["@braintree/sanitize-url@6.0.4", "", {}, "sha512-s3jaWicZd0pkP0jf5ysyHUI/RE7MHos6qlToFcGWXVp+ykHOy77OUMrfbgJ9it2C5bow7OIQwYYaHjk9XlBQ2A=="],
+
+    "cytoscape-fcose/cose-base": ["cose-base@2.2.0", "", { "dependencies": { "layout-base": "^2.0.0" } }, "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g=="],
+
+    "d3-dsv/commander": ["commander@7.2.0", "", {}, "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="],
+
+    "d3-sankey/d3-array": ["d3-array@2.12.1", "", { "dependencies": { "internmap": "^1.0.0" } }, "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ=="],
+
+    "d3-sankey/d3-shape": ["d3-shape@1.3.7", "", { "dependencies": { "d3-path": "1" } }, "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw=="],
+
     "http-errors/statuses": ["statuses@2.0.1", "", {}, "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="],
+
+    "mlly/pkg-types": ["pkg-types@1.3.1", "", { "dependencies": { "confbox": "^0.1.8", "mlly": "^1.7.4", "pathe": "^2.0.1" } }, "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ=="],
+
+    "cytoscape-fcose/cose-base/layout-base": ["layout-base@2.0.1", "", {}, "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg=="],
+
+    "d3-sankey/d3-array/internmap": ["internmap@1.0.1", "", {}, "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="],
+
+    "d3-sankey/d3-shape/d3-path": ["d3-path@1.0.9", "", {}, "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="],
+
+    "mlly/pkg-types/confbox": ["confbox@0.1.8", "", {}, "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w=="],
   }
 }

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,0 +1,82 @@
+/* SPDX-FileCopyrightText: 2025-present Kriasoft */
+/* SPDX-License-Identifier: MIT */
+
+import { withMermaid } from "vitepress-plugin-mermaid";
+
+// https://vitepress.dev/reference/site-config
+export default withMermaid({
+  base: "/oauth-callback/",
+  title: "🔐 \u00A0OAuth Callback",
+  description:
+    "OAuth 2.0 callback handler for CLI tools & desktop apps. Cross-runtime (Node.js/Deno/Bun), MCP SDK integration, minimal deps, TypeScript-first.",
+  themeConfig: {
+    // https://vitepress.dev/reference/default-theme-config
+    nav: [
+      { text: "Guide", link: "/getting-started" },
+      { text: "API", link: "/api/get-auth-code" },
+      { text: "Examples", link: "/examples/notion" },
+      {
+        text: "v1.2.0",
+        items: [
+          {
+            text: "Release Notes",
+            link: "https://github.com/kriasoft/oauth-callback/releases",
+          },
+          {
+            text: "npm",
+            link: "https://www.npmjs.com/package/oauth-callback",
+          },
+        ],
+      },
+    ],
+
+    sidebar: [
+      {
+        text: "Introduction",
+        items: [
+          { text: "What is OAuth Callback?", link: "/what-is-oauth-callback" },
+          { text: "Getting Started", link: "/getting-started" },
+          { text: "Core Concepts", link: "/core-concepts" },
+        ],
+      },
+      {
+        text: "API Reference",
+        items: [
+          { text: "getAuthCode", link: "/api/get-auth-code" },
+          { text: "browserAuth", link: "/api/browser-auth" },
+          { text: "Storage Providers", link: "/api/storage-providers" },
+          { text: "OAuthError", link: "/api/oauth-error" },
+          { text: "TypeScript Types", link: "/api/types" },
+        ],
+      },
+      {
+        text: "Examples",
+        items: [
+          { text: "Notion MCP", link: "/examples/notion" },
+          { text: "Linear MCP", link: "/examples/linear" },
+        ],
+      },
+    ],
+
+    search: {
+      provider: "local",
+    },
+
+    editLink: {
+      pattern:
+        "https://github.com/kriasoft/oauth-callback/edit/main/docs/:path",
+      text: "Edit this page on GitHub",
+    },
+
+    socialLinks: [
+      { icon: "github", link: "https://github.com/kriasoft/oauth-callback" },
+      { icon: "npm", link: "https://www.npmjs.com/package/oauth-callback" },
+      { icon: "discord", link: "https://discord.gg/bSsv7XM" },
+    ],
+
+    footer: {
+      message: "Released under the MIT License.",
+      copyright: "Copyright © 2025-present Konstantin Tarkus",
+    },
+  },
+});

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -1,0 +1,55 @@
+---
+outline: deep
+---
+
+# Runtime API Examples
+
+This page demonstrates usage of some of the runtime APIs provided by VitePress.
+
+The main `useData()` API can be used to access site, theme, and page data for the current page. It works in both `.md` and `.vue` files:
+
+```md
+<script setup>
+import { useData } from 'vitepress'
+
+const { theme, page, frontmatter } = useData()
+</script>
+
+## Results
+
+### Theme Data
+
+<pre>{{ theme }}</pre>
+
+### Page Data
+
+<pre>{{ page }}</pre>
+
+### Page Frontmatter
+
+<pre>{{ frontmatter }}</pre>
+```
+
+<script setup>
+import { useData } from 'vitepress'
+
+const { site, theme, page, frontmatter } = useData()
+</script>
+
+## Results
+
+### Theme Data
+
+<pre>{{ theme }}</pre>
+
+### Page Data
+
+<pre>{{ page }}</pre>
+
+### Page Frontmatter
+
+<pre>{{ frontmatter }}</pre>
+
+## More
+
+Check out the documentation for the [full list of runtime APIs](https://vitepress.dev/reference/runtime-api#usedata).

--- a/docs/api/browser-auth.md
+++ b/docs/api/browser-auth.md
@@ -1,0 +1,805 @@
+---
+title: browserAuth
+description: MCP SDK-compatible OAuth provider for browser-based authentication flows with Dynamic Client Registration support.
+---
+
+# browserAuth
+
+The `browserAuth` function creates an OAuth provider that integrates seamlessly with the Model Context Protocol (MCP) SDK. It handles the entire OAuth flow including Dynamic Client Registration, token management, and automatic refresh — all through a browser-based authorization flow.
+
+## Function Signature
+
+```typescript
+function browserAuth(options?: BrowserAuthOptions): OAuthClientProvider;
+```
+
+## Parameters
+
+### BrowserAuthOptions
+
+| Property       | Type                     | Default           | Description                        |
+| -------------- | ------------------------ | ----------------- | ---------------------------------- |
+| `clientId`     | `string`                 | _none_            | Pre-registered OAuth client ID     |
+| `clientSecret` | `string`                 | _none_            | Pre-registered OAuth client secret |
+| `scope`        | `string`                 | _none_            | OAuth scopes to request            |
+| `port`         | `number`                 | `3000`            | Port for local callback server     |
+| `hostname`     | `string`                 | `"localhost"`     | Hostname to bind server to         |
+| `callbackPath` | `string`                 | `"/callback"`     | URL path for OAuth callback        |
+| `store`        | `TokenStore`             | `inMemoryStore()` | Token storage implementation       |
+| `storeKey`     | `string`                 | `"mcp-tokens"`    | Storage key prefix                 |
+| `openBrowser`  | `boolean \| string`      | `true`            | Auto-open browser                  |
+| `authTimeout`  | `number`                 | `300000`          | Auth timeout in ms (5 min)         |
+| `usePKCE`      | `boolean`                | `true`            | Enable PKCE for security           |
+| `successHtml`  | `string`                 | _built-in_        | Custom success page HTML           |
+| `errorHtml`    | `string`                 | _built-in_        | Custom error page HTML             |
+| `onRequest`    | `(req: Request) => void` | _none_            | Request logging callback           |
+
+## Return Value
+
+Returns an `OAuthClientProvider` instance that implements the MCP SDK authentication interface:
+
+```typescript
+interface OAuthClientProvider {
+  // Called by MCP SDK for authentication
+  redirectToAuthorization(authorizationUrl: URL): Promise<void>;
+
+  // Token management
+  tokens(): Promise<OAuthTokens | undefined>;
+  saveTokens(tokens: OAuthTokens): Promise<void>;
+
+  // Dynamic Client Registration support
+  clientInformation(): Promise<OAuthClientInformation | undefined>;
+  saveClientInformation(info: OAuthClientInformationFull): Promise<void>;
+
+  // PKCE support
+  codeVerifier(): Promise<string>;
+  saveCodeVerifier(verifier: string): Promise<void>;
+
+  // State management
+  state(): Promise<string>;
+  invalidateCredentials(
+    scope: "all" | "client" | "tokens" | "verifier",
+  ): Promise<void>;
+}
+```
+
+## Basic Usage
+
+### Simple MCP Client
+
+The simplest usage with default settings:
+
+```typescript
+import { browserAuth } from "oauth-callback/mcp";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+
+// Create OAuth provider with defaults
+const authProvider = browserAuth();
+
+// Use with MCP transport
+const transport = new StreamableHTTPClientTransport(
+  new URL("https://mcp.example.com"),
+  { authProvider },
+);
+
+const client = new Client(
+  { name: "my-app", version: "1.0.0" },
+  { capabilities: {} },
+);
+
+await client.connect(transport);
+```
+
+### With Token Persistence
+
+Store tokens across sessions:
+
+```typescript
+import { browserAuth, fileStore } from "oauth-callback/mcp";
+
+const authProvider = browserAuth({
+  store: fileStore(), // Persists to ~/.mcp/tokens.json
+  scope: "read write",
+});
+```
+
+## Advanced Usage
+
+### Pre-Registered OAuth Clients
+
+If you have pre-registered OAuth credentials:
+
+```typescript
+const authProvider = browserAuth({
+  clientId: process.env.OAUTH_CLIENT_ID,
+  clientSecret: process.env.OAUTH_CLIENT_SECRET,
+  scope: "read write admin",
+  store: fileStore(),
+});
+```
+
+### Custom Storage Location
+
+Store tokens in a specific location:
+
+```typescript
+import { browserAuth, fileStore } from "oauth-callback/mcp";
+
+const authProvider = browserAuth({
+  store: fileStore("/path/to/my-tokens.json"),
+  storeKey: "my-app-production", // Namespace for multiple environments
+});
+```
+
+### Custom Port and Callback Path
+
+Configure the callback server:
+
+```typescript
+const authProvider = browserAuth({
+  port: 8080,
+  hostname: "127.0.0.1",
+  callbackPath: "/oauth/callback",
+  store: fileStore(),
+});
+```
+
+::: warning Redirect URI Configuration
+Ensure your OAuth app's redirect URI matches your configuration:
+
+- Configuration: `port: 8080`, `callbackPath: "/oauth/callback"`
+- Redirect URI: `http://localhost:8080/oauth/callback`
+  :::
+
+### Custom HTML Pages
+
+Provide branded callback pages:
+
+```typescript
+const authProvider = browserAuth({
+  successHtml: `
+    <!DOCTYPE html>
+    <html>
+      <head>
+        <title>Success!</title>
+        <style>
+          body {
+            font-family: -apple-system, system-ui, sans-serif;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            height: 100vh;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            color: white;
+            margin: 0;
+          }
+          .container {
+            text-align: center;
+            padding: 2rem;
+          }
+          h1 { font-size: 3rem; margin-bottom: 1rem; }
+          p { font-size: 1.2rem; opacity: 0.9; }
+        </style>
+      </head>
+      <body>
+        <div class="container">
+          <h1>🎉 Success!</h1>
+          <p>Authorization complete. You can close this window.</p>
+        </div>
+      </body>
+    </html>
+  `,
+  errorHtml: `
+    <!DOCTYPE html>
+    <html>
+      <body>
+        <h1>Authorization Failed</h1>
+        <p>Error: {{error}}</p>
+        <p>{{error_description}}</p>
+      </body>
+    </html>
+  `,
+});
+```
+
+### Request Logging
+
+Monitor OAuth flow for debugging:
+
+```typescript
+const authProvider = browserAuth({
+  onRequest: (req) => {
+    const url = new URL(req.url);
+    console.log(`[OAuth] ${req.method} ${url.pathname}`);
+
+    if (url.pathname === "/callback") {
+      console.log("[OAuth] Callback params:", url.searchParams.toString());
+    }
+  },
+  store: fileStore(),
+});
+```
+
+### Headless/CI Environment
+
+Disable browser auto-opening for automated environments:
+
+```typescript
+const authProvider = browserAuth({
+  openBrowser: false,
+  authTimeout: 10000, // Shorter timeout for CI
+  store: inMemoryStore(),
+});
+```
+
+## Dynamic Client Registration
+
+OAuth Callback supports [RFC 7591](https://www.rfc-editor.org/rfc/rfc7591.html) Dynamic Client Registration, allowing automatic OAuth client registration:
+
+### How It Works
+
+```mermaid
+sequenceDiagram
+    participant App
+    participant browserAuth
+    participant MCP Server
+    participant Auth Server
+
+    App->>browserAuth: Create provider (no client_id)
+    App->>MCP Server: Connect via transport
+    MCP Server->>App: Requires authentication
+    App->>browserAuth: Initiate OAuth
+    browserAuth->>Auth Server: POST /register (DCR)
+    Auth Server->>browserAuth: Return client_id, client_secret
+    browserAuth->>browserAuth: Store credentials
+    browserAuth->>Auth Server: Start OAuth flow
+    Auth Server->>browserAuth: Return authorization code
+    browserAuth->>App: Authentication complete
+```
+
+### DCR Example
+
+No pre-registration needed:
+
+```typescript
+// No clientId or clientSecret required!
+const authProvider = browserAuth({
+  scope: "read write",
+  store: fileStore(), // Persist dynamically registered client
+});
+
+// The provider will automatically:
+// 1. Register a new OAuth client on first use
+// 2. Store the client credentials
+// 3. Reuse them for future sessions
+```
+
+### Benefits of DCR
+
+- **Zero Configuration**: Users don't need to manually register OAuth apps
+- **Automatic Setup**: Client registration happens transparently
+- **Credential Persistence**: Registered clients are reused across sessions
+- **Simplified Distribution**: Ship MCP clients without OAuth setup instructions
+
+## Token Storage
+
+### Storage Interfaces
+
+OAuth Callback provides two storage interfaces:
+
+#### TokenStore (Basic)
+
+```typescript
+interface TokenStore {
+  get(key: string): Promise<Tokens | null>;
+  set(key: string, tokens: Tokens): Promise<void>;
+  delete(key: string): Promise<void>;
+  clear(): Promise<void>;
+}
+```
+
+#### OAuthStore (Extended)
+
+```typescript
+interface OAuthStore extends TokenStore {
+  getClient(key: string): Promise<ClientInfo | null>;
+  setClient(key: string, client: ClientInfo): Promise<void>;
+  getSession(key: string): Promise<OAuthSession | null>;
+  setSession(key: string, session: OAuthSession): Promise<void>;
+}
+```
+
+### Built-in Implementations
+
+#### In-Memory Store
+
+Ephemeral storage (tokens lost on restart):
+
+```typescript
+import { browserAuth, inMemoryStore } from "oauth-callback/mcp";
+
+const authProvider = browserAuth({
+  store: inMemoryStore(),
+});
+```
+
+**Use cases:**
+
+- Development and testing
+- Short-lived CLI sessions
+- Maximum security (no persistence)
+
+#### File Store
+
+Persistent storage to JSON file:
+
+```typescript
+import { browserAuth, fileStore } from "oauth-callback/mcp";
+
+// Default location: ~/.mcp/tokens.json
+const authProvider = browserAuth({
+  store: fileStore(),
+});
+
+// Custom location
+const customAuth = browserAuth({
+  store: fileStore("/path/to/tokens.json"),
+});
+```
+
+**Use cases:**
+
+- Desktop applications
+- Long-running services
+- Multi-session authentication
+
+### Custom Storage Implementation
+
+Implement your own storage backend:
+
+```typescript
+import { TokenStore, Tokens } from "oauth-callback/mcp";
+
+class RedisStore implements TokenStore {
+  constructor(private redis: RedisClient) {}
+
+  async get(key: string): Promise<Tokens | null> {
+    const data = await this.redis.get(key);
+    return data ? JSON.parse(data) : null;
+  }
+
+  async set(key: string, tokens: Tokens): Promise<void> {
+    await this.redis.set(key, JSON.stringify(tokens));
+  }
+
+  async delete(key: string): Promise<void> {
+    await this.redis.del(key);
+  }
+
+  async clear(): Promise<void> {
+    // Clear all tokens with pattern matching
+    const keys = await this.redis.keys("mcp-tokens:*");
+    if (keys.length > 0) {
+      await this.redis.del(...keys);
+    }
+  }
+}
+
+// Use custom store
+const authProvider = browserAuth({
+  store: new RedisStore(redisClient),
+});
+```
+
+## Security Features
+
+### PKCE (Proof Key for Code Exchange)
+
+PKCE is enabled by default for enhanced security:
+
+```typescript
+const authProvider = browserAuth({
+  usePKCE: true, // Default: true
+});
+```
+
+PKCE prevents authorization code interception attacks by:
+
+1. Generating a cryptographic code verifier
+2. Sending a hashed challenge with the authorization request
+3. Proving possession of the verifier during token exchange
+
+### State Parameter
+
+The provider automatically generates secure state parameters:
+
+```typescript
+// State is automatically generated and validated
+const authProvider = browserAuth();
+// No manual state handling needed!
+```
+
+### Token Expiry Management
+
+Tokens are automatically managed with expiry tracking:
+
+```typescript
+// The provider automatically:
+// 1. Tracks token expiry time
+// 2. Returns undefined for expired tokens
+// 3. Attempts refresh when refresh tokens are available
+```
+
+### Secure Storage
+
+File storage uses restrictive permissions:
+
+```typescript
+// Files are created with mode 0600 (owner read/write only)
+const authProvider = browserAuth({
+  store: fileStore(), // Secure file permissions
+});
+```
+
+## Error Handling
+
+### OAuth Errors
+
+The provider handles OAuth-specific errors:
+
+```typescript
+try {
+  await client.connect(transport);
+} catch (error) {
+  if (error.message.includes("access_denied")) {
+    console.log("User cancelled authorization");
+  } else if (error.message.includes("invalid_scope")) {
+    console.log("Requested scope not available");
+  } else {
+    console.error("Connection failed:", error);
+  }
+}
+```
+
+### Retry Logic
+
+The provider includes automatic retry for transient failures:
+
+```typescript
+// Built-in retry logic:
+// - 3 attempts for authorization
+// - Exponential backoff between retries
+// - OAuth errors are not retried (user-actionable)
+```
+
+### Timeout Handling
+
+Configure timeout for different scenarios:
+
+```typescript
+const authProvider = browserAuth({
+  authTimeout: 600000, // 10 minutes for first-time setup
+});
+```
+
+## Complete Examples
+
+### Notion MCP Integration
+
+Full example with Dynamic Client Registration:
+
+```typescript
+import { browserAuth, fileStore } from "oauth-callback/mcp";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+
+async function connectToNotion() {
+  // No client credentials needed - uses DCR!
+  const authProvider = browserAuth({
+    store: fileStore(), // Persist tokens and client registration
+    scope: "read write",
+    onRequest: (req) => {
+      console.log(`[Notion OAuth] ${new URL(req.url).pathname}`);
+    },
+  });
+
+  const transport = new StreamableHTTPClientTransport(
+    new URL("https://mcp.notion.com/mcp"),
+    { authProvider },
+  );
+
+  const client = new Client(
+    { name: "notion-client", version: "1.0.0" },
+    { capabilities: {} },
+  );
+
+  try {
+    await client.connect(transport);
+    console.log("Connected to Notion MCP!");
+
+    // List available tools
+    const tools = await client.listTools();
+    console.log("Available tools:", tools);
+
+    // Use a tool
+    const result = await client.callTool("search", {
+      query: "meeting notes",
+    });
+    console.log("Search results:", result);
+  } catch (error) {
+    console.error("Failed to connect:", error);
+  } finally {
+    await client.close();
+  }
+}
+
+connectToNotion();
+```
+
+### Multi-Environment Configuration
+
+Support development, staging, and production:
+
+```typescript
+import { browserAuth, fileStore } from "oauth-callback/mcp";
+
+function createAuthProvider(environment: "dev" | "staging" | "prod") {
+  const configs = {
+    dev: {
+      port: 3000,
+      store: inMemoryStore(), // No persistence in dev
+      authTimeout: 60000,
+      onRequest: (req) => console.log("[DEV]", req.url),
+    },
+    staging: {
+      port: 3001,
+      store: fileStore("~/.mcp/staging-tokens.json"),
+      storeKey: "staging",
+      authTimeout: 120000,
+    },
+    prod: {
+      port: 3002,
+      store: fileStore("~/.mcp/prod-tokens.json"),
+      storeKey: "production",
+      authTimeout: 300000,
+      clientId: process.env.PROD_CLIENT_ID,
+      clientSecret: process.env.PROD_CLIENT_SECRET,
+    },
+  };
+
+  return browserAuth(configs[environment]);
+}
+
+// Use appropriate environment
+const authProvider = createAuthProvider(
+  process.env.NODE_ENV as "dev" | "staging" | "prod",
+);
+```
+
+### Token Refresh Implementation
+
+While automatic refresh is pending full implementation, you can handle expired tokens:
+
+```typescript
+import { browserAuth, fileStore } from "oauth-callback/mcp";
+
+const authProvider = browserAuth({
+  store: fileStore(),
+  scope: "offline_access", // Request refresh token
+});
+
+async function withTokenRefresh(client: Client, operation: () => Promise<any>) {
+  try {
+    return await operation();
+  } catch (error) {
+    if (
+      error.message.includes("401") ||
+      error.message.includes("unauthorized")
+    ) {
+      console.log("Token expired, re-authenticating...");
+
+      // Clear expired tokens
+      await authProvider.invalidateCredentials("tokens");
+
+      // Reconnect (will trigger new auth)
+      await client.reconnect();
+
+      // Retry operation
+      return await operation();
+    }
+    throw error;
+  }
+}
+
+// Use with automatic retry
+const result = await withTokenRefresh(client, async () => {
+  return await client.callTool("get-data", {});
+});
+```
+
+## Testing
+
+### Unit Testing
+
+Mock the OAuth provider for tests:
+
+```typescript
+import { vi, describe, it, expect } from "vitest";
+
+// Create mock provider
+const mockAuthProvider = {
+  redirectToAuthorization: vi.fn(),
+  tokens: vi.fn().mockResolvedValue({
+    access_token: "test_token",
+    token_type: "Bearer",
+  }),
+  saveTokens: vi.fn(),
+  clientInformation: vi.fn(),
+  saveClientInformation: vi.fn(),
+  state: vi.fn().mockResolvedValue("test_state"),
+  codeVerifier: vi.fn().mockResolvedValue("test_verifier"),
+  saveCodeVerifier: vi.fn(),
+  invalidateCredentials: vi.fn(),
+};
+
+describe("MCP Client", () => {
+  it("should authenticate with OAuth", async () => {
+    const transport = new StreamableHTTPClientTransport(
+      new URL("https://test.example.com"),
+      { authProvider: mockAuthProvider },
+    );
+
+    const client = new Client(
+      { name: "test", version: "1.0.0" },
+      { capabilities: {} },
+    );
+
+    await client.connect(transport);
+
+    expect(mockAuthProvider.tokens).toHaveBeenCalled();
+  });
+});
+```
+
+### Integration Testing
+
+Test with a mock OAuth server:
+
+```typescript
+import { browserAuth, inMemoryStore } from "oauth-callback/mcp";
+import { createMockOAuthServer } from "./test-utils";
+
+describe("OAuth Flow Integration", () => {
+  let mockServer: MockOAuthServer;
+
+  beforeAll(async () => {
+    mockServer = createMockOAuthServer();
+    await mockServer.start();
+  });
+
+  afterAll(async () => {
+    await mockServer.stop();
+  });
+
+  it("should complete full OAuth flow", async () => {
+    const authProvider = browserAuth({
+      port: 3001,
+      openBrowser: false, // Don't open browser in tests
+      store: inMemoryStore(),
+    });
+
+    // Simulate OAuth flow
+    await authProvider.redirectToAuthorization(
+      new URL(`http://localhost:${mockServer.port}/authorize`),
+    );
+
+    const tokens = await authProvider.tokens();
+    expect(tokens?.access_token).toBeDefined();
+  });
+});
+```
+
+## Troubleshooting
+
+### Common Issues
+
+::: details Port Already in Use
+
+```typescript
+// Use a different port
+const authProvider = browserAuth({
+  port: 8080, // Try alternative port
+});
+```
+
+:::
+
+::: details Tokens Not Persisting
+
+```typescript
+// Ensure you're using file store, not in-memory
+const authProvider = browserAuth({
+  store: fileStore(), // ✅ Persistent
+  // store: inMemoryStore() // ❌ Lost on restart
+});
+```
+
+:::
+
+::: details DCR Not Working
+Some servers may not support Dynamic Client Registration:
+
+```typescript
+// Fallback to pre-registered credentials
+const authProvider = browserAuth({
+  clientId: "your-client-id",
+  clientSecret: "your-client-secret",
+});
+```
+
+:::
+
+::: details Browser Not Opening
+
+```typescript
+// Check if running in headless environment
+const authProvider = browserAuth({
+  openBrowser: process.env.CI !== "true",
+});
+```
+
+:::
+
+## API Compatibility
+
+The `browserAuth` provider implements the MCP SDK's `OAuthClientProvider` interface:
+
+| Method                    | Status               | Notes                      |
+| ------------------------- | -------------------- | -------------------------- |
+| `redirectToAuthorization` | ✅ Fully supported   | Opens browser for auth     |
+| `tokens`                  | ✅ Fully supported   | Returns current tokens     |
+| `saveTokens`              | ✅ Fully supported   | Persists to storage        |
+| `clientInformation`       | ✅ Fully supported   | Returns client credentials |
+| `saveClientInformation`   | ✅ Fully supported   | Stores DCR results         |
+| `state`                   | ✅ Fully supported   | Generates secure state     |
+| `codeVerifier`            | ✅ Fully supported   | PKCE verifier              |
+| `saveCodeVerifier`        | ✅ Fully supported   | Stores PKCE verifier       |
+| `invalidateCredentials`   | ✅ Fully supported   | Clears stored data         |
+| `validateResourceURL`     | ✅ Returns undefined | Not applicable             |
+| `getPendingAuthCode`      | ✅ Internal use      | Used by SDK                |
+
+## Migration Guide
+
+### From Manual OAuth to browserAuth
+
+```typescript
+// Before: Manual OAuth implementation
+const code = await getAuthCode(authUrl);
+const tokens = await exchangeCodeForTokens(code);
+// Manual token storage and refresh...
+
+// After: Using browserAuth
+const authProvider = browserAuth({
+  store: fileStore(),
+});
+// Automatic handling of entire OAuth flow!
+```
+
+### From In-Memory to Persistent Storage
+
+```typescript
+// Before: Tokens lost on restart
+const authProvider = browserAuth();
+
+// After: Tokens persist across sessions
+const authProvider = browserAuth({
+  store: fileStore(),
+});
+```
+
+## Related APIs
+
+- [`getAuthCode`](/api/get-auth-code) - Low-level OAuth code capture
+- [`TokenStore`](/api/storage-providers) - Storage interface documentation
+- [`OAuthError`](/api/oauth-error) - OAuth error handling

--- a/docs/api/get-auth-code.md
+++ b/docs/api/get-auth-code.md
@@ -1,0 +1,615 @@
+---
+title: getAuthCode
+description: Core function for capturing OAuth authorization codes via localhost callback in CLI tools and desktop applications.
+---
+
+# getAuthCode
+
+The `getAuthCode` function is the primary API for capturing OAuth authorization codes through a localhost callback. It handles the entire OAuth flow: starting a local server, opening the browser, waiting for the callback, and returning the authorization code.
+
+## Function Signature
+
+```typescript
+function getAuthCode(
+  input: string | GetAuthCodeOptions,
+): Promise<CallbackResult>;
+```
+
+## Parameters
+
+The function accepts either:
+
+- A **string** containing the OAuth authorization URL (uses default options)
+- A **GetAuthCodeOptions** object for advanced configuration
+
+### GetAuthCodeOptions
+
+| Property           | Type                     | Default       | Description                                   |
+| ------------------ | ------------------------ | ------------- | --------------------------------------------- |
+| `authorizationUrl` | `string`                 | _required_    | OAuth authorization URL with query parameters |
+| `port`             | `number`                 | `3000`        | Port for the local callback server            |
+| `hostname`         | `string`                 | `"localhost"` | Hostname to bind the server to                |
+| `callbackPath`     | `string`                 | `"/callback"` | URL path for OAuth callback                   |
+| `timeout`          | `number`                 | `30000`       | Timeout in milliseconds                       |
+| `openBrowser`      | `boolean`                | `true`        | Auto-open browser to auth URL                 |
+| `successHtml`      | `string`                 | _built-in_    | Custom HTML for successful auth               |
+| `errorHtml`        | `string`                 | _built-in_    | Custom HTML template for errors               |
+| `signal`           | `AbortSignal`            | _none_        | For programmatic cancellation                 |
+| `onRequest`        | `(req: Request) => void` | _none_        | Callback for request logging                  |
+
+## Return Value
+
+Returns a `Promise<CallbackResult>` containing:
+
+```typescript
+interface CallbackResult {
+  code: string; // Authorization code
+  state?: string; // State parameter (if provided)
+  [key: string]: any; // Additional query parameters
+}
+```
+
+## Exceptions
+
+The function can throw:
+
+| Error Type   | Condition            | Description                                                     |
+| ------------ | -------------------- | --------------------------------------------------------------- |
+| `OAuthError` | OAuth provider error | Contains `error`, `error_description`, and optional `error_uri` |
+| `Error`      | Timeout              | "Timeout waiting for callback"                                  |
+| `Error`      | Port in use          | "EADDRINUSE" - port already occupied                            |
+| `Error`      | Cancellation         | "Operation aborted" via AbortSignal                             |
+
+## Basic Usage
+
+### Simple Authorization
+
+The simplest usage with just an authorization URL:
+
+```typescript
+import { getAuthCode } from "oauth-callback";
+
+const authUrl =
+  "https://github.com/login/oauth/authorize?" +
+  new URLSearchParams({
+    client_id: "your_client_id",
+    redirect_uri: "http://localhost:3000/callback",
+    scope: "user:email",
+    state: "random_state",
+  });
+
+const result = await getAuthCode(authUrl);
+console.log("Authorization code:", result.code);
+console.log("State:", result.state);
+```
+
+### With Configuration Object
+
+Using the options object for more control:
+
+```typescript
+const result = await getAuthCode({
+  authorizationUrl: authUrl,
+  port: 8080,
+  timeout: 60000,
+  hostname: "127.0.0.1",
+});
+```
+
+## Advanced Usage
+
+### Custom Port Configuration
+
+When port 3000 is unavailable or you've registered a different redirect URI:
+
+```typescript
+const result = await getAuthCode({
+  authorizationUrl: "https://oauth.example.com/authorize?...",
+  port: 8888,
+  callbackPath: "/oauth/callback", // Custom path
+  hostname: "127.0.0.1", // Specific IP binding
+});
+```
+
+::: warning Port Configuration
+Ensure the port and path match your OAuth app's registered redirect URI:
+
+- Registered: `http://localhost:8888/oauth/callback`
+- Configuration must use: `port: 8888`, `callbackPath: "/oauth/callback"`
+  :::
+
+### Custom HTML Templates
+
+Provide branded success and error pages:
+
+```typescript
+const result = await getAuthCode({
+  authorizationUrl: authUrl,
+  successHtml: `
+    <!DOCTYPE html>
+    <html>
+      <head>
+        <title>Success!</title>
+        <style>
+          body { 
+            font-family: system-ui; 
+            display: flex; 
+            justify-content: center; 
+            align-items: center; 
+            height: 100vh;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            color: white;
+          }
+        </style>
+      </head>
+      <body>
+        <div>
+          <h1>✨ Authorization Successful!</h1>
+          <p>You can close this window and return to the app.</p>
+        </div>
+      </body>
+    </html>
+  `,
+  errorHtml: `
+    <!DOCTYPE html>
+    <html>
+      <body>
+        <h1>Authorization Failed</h1>
+        <p>Error: {{error}}</p>
+        <p>{{error_description}}</p>
+        <a href="{{error_uri}}">More information</a>
+      </body>
+    </html>
+  `,
+});
+```
+
+::: tip Template Placeholders
+Error templates support these placeholders:
+
+- `{{error}}` - OAuth error code
+- `{{error_description}}` - Human-readable description
+- `{{error_uri}}` - Link to error documentation
+  :::
+
+### Request Logging
+
+Monitor OAuth flow for debugging:
+
+```typescript
+const result = await getAuthCode({
+  authorizationUrl: authUrl,
+  onRequest: (req) => {
+    const url = new URL(req.url);
+    console.log(`[${new Date().toISOString()}] ${req.method} ${url.pathname}`);
+
+    // Log specific paths
+    if (url.pathname === "/callback") {
+      console.log(
+        "Callback received with params:",
+        url.searchParams.toString(),
+      );
+    }
+  },
+});
+```
+
+### Timeout Handling
+
+Configure timeout for different scenarios:
+
+```typescript
+try {
+  const result = await getAuthCode({
+    authorizationUrl: authUrl,
+    timeout: 120000, // 2 minutes for first-time users
+  });
+} catch (error) {
+  if (error.message === "Timeout waiting for callback") {
+    console.error("Authorization took too long. Please try again.");
+  }
+}
+```
+
+### Programmatic Cancellation
+
+Support user-initiated cancellation:
+
+```typescript
+const controller = new AbortController();
+
+// Listen for Ctrl+C
+process.on("SIGINT", () => {
+  console.log("\nCancelling authorization...");
+  controller.abort();
+});
+
+// Set a maximum time limit
+const timeoutId = setTimeout(() => {
+  console.log("Authorization time limit reached");
+  controller.abort();
+}, 300000); // 5 minutes
+
+try {
+  const result = await getAuthCode({
+    authorizationUrl: authUrl,
+    signal: controller.signal,
+  });
+
+  clearTimeout(timeoutId);
+  console.log("Success! Code:", result.code);
+} catch (error) {
+  if (error.message === "Operation aborted") {
+    console.log("Authorization was cancelled");
+  }
+}
+```
+
+### Manual Browser Control
+
+For environments where automatic browser opening doesn't work:
+
+```typescript
+const result = await getAuthCode({
+  authorizationUrl: authUrl,
+  openBrowser: false, // Don't auto-open
+});
+
+// Manually instruct user
+console.log("Please open this URL in your browser:");
+console.log(authUrl);
+```
+
+## Error Handling
+
+### Comprehensive Error Handling
+
+Handle all possible error scenarios:
+
+```typescript
+import { getAuthCode, OAuthError } from "oauth-callback";
+
+try {
+  const result = await getAuthCode(authUrl);
+  // Success - exchange code for token
+  return result.code;
+} catch (error) {
+  if (error instanceof OAuthError) {
+    // OAuth-specific errors from provider
+    switch (error.error) {
+      case "access_denied":
+        console.log("User cancelled authorization");
+        break;
+
+      case "invalid_scope":
+        console.error("Requested scope is invalid:", error.error_description);
+        break;
+
+      case "server_error":
+        console.error("OAuth server error. Please try again later.");
+        break;
+
+      case "temporarily_unavailable":
+        console.error("OAuth service is temporarily unavailable");
+        break;
+
+      default:
+        console.error(`OAuth error: ${error.error}`);
+        if (error.error_description) {
+          console.error(`Details: ${error.error_description}`);
+        }
+        if (error.error_uri) {
+          console.error(`More info: ${error.error_uri}`);
+        }
+    }
+  } else if (error.code === "EADDRINUSE") {
+    console.error(`Port ${port} is already in use. Try a different port.`);
+  } else if (error.message === "Timeout waiting for callback") {
+    console.error("Authorization timed out. Please try again.");
+  } else if (error.message === "Operation aborted") {
+    console.log("Authorization was cancelled by user");
+  } else {
+    // Unexpected errors
+    console.error("Unexpected error:", error);
+  }
+
+  throw error; // Re-throw for upstream handling
+}
+```
+
+### Retry Logic
+
+Implement retry for transient failures:
+
+```typescript
+async function getAuthCodeWithRetry(
+  authUrl: string,
+  maxAttempts = 3,
+): Promise<string> {
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      const result = await getAuthCode({
+        authorizationUrl: authUrl,
+        port: 3000 + attempt - 1, // Try different ports
+        timeout: 30000 * attempt, // Increase timeout each attempt
+      });
+      return result.code;
+    } catch (error) {
+      console.log(`Attempt ${attempt} failed:`, error.message);
+
+      if (attempt === maxAttempts) {
+        throw error;
+      }
+
+      // Don't retry user cancellations
+      if (error instanceof OAuthError && error.error === "access_denied") {
+        throw error;
+      }
+
+      console.log(`Retrying... (${attempt + 1}/${maxAttempts})`);
+    }
+  }
+}
+```
+
+## Security Best Practices
+
+### State Parameter Validation
+
+Always validate the state parameter to prevent CSRF attacks:
+
+```typescript
+import { randomBytes } from "crypto";
+
+// Generate secure random state
+const state = randomBytes(32).toString("base64url");
+
+const authUrl = new URL("https://oauth.example.com/authorize");
+authUrl.searchParams.set("client_id", CLIENT_ID);
+authUrl.searchParams.set("redirect_uri", "http://localhost:3000/callback");
+authUrl.searchParams.set("state", state);
+authUrl.searchParams.set("scope", "read write");
+
+const result = await getAuthCode(authUrl.toString());
+
+// Validate state matches
+if (result.state !== state) {
+  throw new Error("State mismatch - possible CSRF attack!");
+}
+
+// Safe to use authorization code
+console.log("Valid authorization code:", result.code);
+```
+
+### PKCE Implementation
+
+Implement Proof Key for Code Exchange for public clients:
+
+```typescript
+import { createHash, randomBytes } from "crypto";
+
+// Generate PKCE challenge
+const verifier = randomBytes(32).toString("base64url");
+const challenge = createHash("sha256").update(verifier).digest("base64url");
+
+// Include challenge in authorization request
+const authUrl = new URL("https://oauth.example.com/authorize");
+authUrl.searchParams.set("code_challenge", challenge);
+authUrl.searchParams.set("code_challenge_method", "S256");
+// ... other parameters
+
+const result = await getAuthCode(authUrl.toString());
+
+// Include verifier when exchanging code
+const tokenResponse = await fetch("https://oauth.example.com/token", {
+  method: "POST",
+  body: new URLSearchParams({
+    grant_type: "authorization_code",
+    code: result.code,
+    code_verifier: verifier, // Include PKCE verifier
+    client_id: CLIENT_ID,
+    redirect_uri: "http://localhost:3000/callback",
+  }),
+});
+```
+
+## Complete Examples
+
+### GitHub OAuth Integration
+
+Full example with error handling and token exchange:
+
+```typescript
+import { getAuthCode, OAuthError } from "oauth-callback";
+
+async function authenticateWithGitHub() {
+  const CLIENT_ID = process.env.GITHUB_CLIENT_ID;
+  const CLIENT_SECRET = process.env.GITHUB_CLIENT_SECRET;
+
+  // Build authorization URL with all parameters
+  const authUrl = new URL("https://github.com/login/oauth/authorize");
+  authUrl.searchParams.set("client_id", CLIENT_ID);
+  authUrl.searchParams.set("redirect_uri", "http://localhost:3000/callback");
+  authUrl.searchParams.set("scope", "user:email repo");
+  authUrl.searchParams.set("state", crypto.randomUUID());
+
+  try {
+    // Get authorization code
+    console.log("Opening browser for GitHub authorization...");
+    const result = await getAuthCode({
+      authorizationUrl: authUrl.toString(),
+      timeout: 60000,
+      successHtml: "<h1>✅ GitHub authorization successful!</h1>",
+    });
+
+    // Exchange code for access token
+    console.log("Exchanging code for access token...");
+    const tokenResponse = await fetch(
+      "https://github.com/login/oauth/access_token",
+      {
+        method: "POST",
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          client_id: CLIENT_ID,
+          client_secret: CLIENT_SECRET,
+          code: result.code,
+        }),
+      },
+    );
+
+    const tokens = await tokenResponse.json();
+
+    if (tokens.error) {
+      throw new Error(`Token exchange failed: ${tokens.error_description}`);
+    }
+
+    // Use access token to get user info
+    const userResponse = await fetch("https://api.github.com/user", {
+      headers: {
+        Authorization: `Bearer ${tokens.access_token}`,
+        Accept: "application/vnd.github.v3+json",
+      },
+    });
+
+    const user = await userResponse.json();
+    console.log(`Authenticated as: ${user.login}`);
+
+    return tokens.access_token;
+  } catch (error) {
+    if (error instanceof OAuthError) {
+      console.error("GitHub authorization failed:", error.error_description);
+    } else {
+      console.error("Authentication error:", error.message);
+    }
+    throw error;
+  }
+}
+```
+
+### Multi-Provider Support
+
+Handle multiple OAuth providers with a unified interface:
+
+```typescript
+type Provider = "github" | "google" | "microsoft";
+
+async function authenticate(provider: Provider): Promise<string> {
+  const configs = {
+    github: {
+      authUrl: "https://github.com/login/oauth/authorize",
+      tokenUrl: "https://github.com/login/oauth/access_token",
+      scope: "user:email",
+    },
+    google: {
+      authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+      tokenUrl: "https://oauth2.googleapis.com/token",
+      scope: "openid email profile",
+    },
+    microsoft: {
+      authUrl: "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
+      tokenUrl: "https://login.microsoftonline.com/common/oauth2/v2.0/token",
+      scope: "user.read",
+    },
+  };
+
+  const config = configs[provider];
+  const authUrl = new URL(config.authUrl);
+
+  // Add provider-specific parameters
+  authUrl.searchParams.set(
+    "client_id",
+    process.env[`${provider.toUpperCase()}_CLIENT_ID`],
+  );
+  authUrl.searchParams.set("redirect_uri", "http://localhost:3000/callback");
+  authUrl.searchParams.set("scope", config.scope);
+  authUrl.searchParams.set("response_type", "code");
+  authUrl.searchParams.set("state", crypto.randomUUID());
+
+  if (provider === "google") {
+    authUrl.searchParams.set("access_type", "offline");
+    authUrl.searchParams.set("prompt", "consent");
+  }
+
+  const result = await getAuthCode({
+    authorizationUrl: authUrl.toString(),
+    timeout: 90000,
+    onRequest: (req) => {
+      console.log(`[${provider}] ${req.method} ${new URL(req.url).pathname}`);
+    },
+  });
+
+  return result.code;
+}
+```
+
+## Testing
+
+### Unit Testing
+
+Mock the OAuth flow for testing:
+
+```typescript
+import { getAuthCode } from "oauth-callback";
+import { describe, it, expect } from "vitest";
+
+describe("OAuth Flow", () => {
+  it("should capture authorization code", async () => {
+    // Start mock OAuth server
+    const mockServer = createMockOAuthServer();
+    await mockServer.start();
+
+    const result = await getAuthCode({
+      authorizationUrl: `http://localhost:${mockServer.port}/authorize`,
+      port: 3001,
+      openBrowser: false, // Don't open real browser in tests
+      timeout: 5000,
+    });
+
+    expect(result.code).toBe("test_auth_code");
+    expect(result.state).toBe("test_state");
+
+    await mockServer.stop();
+  });
+
+  it("should handle OAuth errors", async () => {
+    const mockServer = createMockOAuthServer({
+      error: "access_denied",
+    });
+    await mockServer.start();
+
+    await expect(
+      getAuthCode({
+        authorizationUrl: `http://localhost:${mockServer.port}/authorize`,
+        openBrowser: false,
+      }),
+    ).rejects.toThrow(OAuthError);
+
+    await mockServer.stop();
+  });
+});
+```
+
+## Migration Guide
+
+### From v1.x to v2.x
+
+```typescript
+// v1.x (old)
+const code = await captureAuthCode(url, 3000);
+
+// v2.x (new)
+const result = await getAuthCode({
+  authorizationUrl: url,
+  port: 3000,
+});
+const code = result.code;
+```
+
+## Related APIs
+
+- [`OAuthError`](/api/oauth-error) - OAuth-specific error class
+- [`browserAuth`](/api/browser-auth) - MCP SDK integration provider
+- [`TokenStore`](/api/storage-providers) - Token storage interface

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,0 +1,422 @@
+---
+title: API Reference
+description: Complete API documentation for OAuth Callback library functions, types, and interfaces.
+---
+
+# API Reference
+
+OAuth Callback provides a comprehensive set of APIs for handling OAuth 2.0 authorization flows in CLI tools, desktop applications, and Model Context Protocol (MCP) clients. The library is designed with modern Web Standards APIs and works across Node.js 18+, Deno, and Bun.
+
+## Quick Navigation
+
+<div class="api-grid">
+
+### Core Functions
+
+- [**getAuthCode**](/api/get-auth-code) - Capture OAuth authorization codes via localhost callback
+- [**browserAuth**](/api/browser-auth) - MCP SDK-compatible OAuth provider with DCR support
+
+### Storage Providers
+
+- [**Storage Providers**](/api/storage-providers) - Token persistence interfaces and implementations
+- **inMemoryStore** - Ephemeral in-memory token storage
+- **fileStore** - Persistent file-based token storage
+
+### Error Handling
+
+- [**OAuthError**](/api/oauth-error) - OAuth-specific error class with RFC 6749 compliance
+
+### Type Definitions
+
+- [**Types**](/api/types) - Complete TypeScript type reference
+
+</div>
+
+## Import Methods
+
+OAuth Callback supports multiple import patterns to suit different use cases:
+
+### Main Package Import
+
+```typescript
+// Core functionality
+import { getAuthCode, OAuthError } from "oauth-callback";
+
+// Namespace import for MCP features
+import { mcp } from "oauth-callback";
+const authProvider = mcp.browserAuth({ store: mcp.fileStore() });
+```
+
+### MCP-Specific Import
+
+```typescript
+// Direct MCP imports (recommended for MCP projects)
+import { browserAuth, fileStore, inMemoryStore } from "oauth-callback/mcp";
+import type { TokenStore, OAuthStore, Tokens } from "oauth-callback/mcp";
+```
+
+## Core APIs
+
+### getAuthCode(input)
+
+The primary function for capturing OAuth authorization codes through a localhost callback server.
+
+```typescript
+function getAuthCode(
+  input: string | GetAuthCodeOptions,
+): Promise<CallbackResult>;
+```
+
+**Key Features:**
+
+- Automatic browser opening
+- Configurable port and timeout
+- Custom HTML templates
+- AbortSignal support
+- Comprehensive error handling
+
+[**Full Documentation →**](/api/get-auth-code)
+
+### browserAuth(options)
+
+MCP SDK-compatible OAuth provider that handles the complete OAuth flow including Dynamic Client Registration.
+
+```typescript
+function browserAuth(options?: BrowserAuthOptions): OAuthClientProvider;
+```
+
+**Key Features:**
+
+- Dynamic Client Registration (RFC 7591)
+- Automatic token refresh
+- PKCE support (RFC 7636)
+- Flexible token storage
+- MCP SDK integration
+
+[**Full Documentation →**](/api/browser-auth)
+
+## Storage APIs
+
+### Storage Interfaces
+
+OAuth Callback provides two storage interfaces for different levels of state management:
+
+```typescript
+// Basic token storage
+interface TokenStore {
+  get(key: string): Promise<Tokens | null>;
+  set(key: string, tokens: Tokens): Promise<void>;
+  delete(key: string): Promise<void>;
+  clear(): Promise<void>;
+}
+
+// Extended storage with DCR support
+interface OAuthStore extends TokenStore {
+  getClient(key: string): Promise<ClientInfo | null>;
+  setClient(key: string, client: ClientInfo): Promise<void>;
+  getSession(key: string): Promise<OAuthSession | null>;
+  setSession(key: string, session: OAuthSession): Promise<void>;
+}
+```
+
+[**Full Documentation →**](/api/storage-providers)
+
+### Built-in Implementations
+
+#### inMemoryStore()
+
+Ephemeral storage that keeps tokens in memory:
+
+```typescript
+const authProvider = browserAuth({
+  store: inMemoryStore(), // Tokens lost on restart
+});
+```
+
+#### fileStore(filepath?)
+
+Persistent storage that saves tokens to a JSON file:
+
+```typescript
+const authProvider = browserAuth({
+  store: fileStore(), // Default: ~/.mcp/tokens.json
+});
+```
+
+## Error Handling
+
+### OAuthError
+
+Specialized error class for OAuth-specific failures:
+
+```typescript
+class OAuthError extends Error {
+  error: string; // OAuth error code
+  error_description?: string; // Human-readable description
+  error_uri?: string; // URI with more information
+}
+```
+
+**Common Error Codes:**
+
+- `access_denied` - User denied authorization
+- `invalid_scope` - Requested scope is invalid
+- `server_error` - Authorization server error
+- `temporarily_unavailable` - Service temporarily down
+
+[**Full Documentation →**](/api/oauth-error)
+
+## Type System
+
+OAuth Callback is fully typed with TypeScript, providing comprehensive type definitions for all APIs:
+
+### Core Types
+
+```typescript
+interface GetAuthCodeOptions {
+  authorizationUrl: string;
+  port?: number;
+  hostname?: string;
+  callbackPath?: string;
+  timeout?: number;
+  openBrowser?: boolean;
+  successHtml?: string;
+  errorHtml?: string;
+  signal?: AbortSignal;
+  onRequest?: (req: Request) => void;
+}
+
+interface CallbackResult {
+  code: string;
+  state?: string;
+  [key: string]: any;
+}
+```
+
+### Storage Types
+
+```typescript
+interface Tokens {
+  accessToken: string;
+  refreshToken?: string;
+  expiresAt?: number;
+  scope?: string;
+}
+
+interface ClientInfo {
+  clientId: string;
+  clientSecret?: string;
+  clientIdIssuedAt?: number;
+  clientSecretExpiresAt?: number;
+}
+```
+
+[**Full Type Reference →**](/api/types)
+
+## Usage Patterns
+
+### Simple OAuth Flow
+
+```typescript
+import { getAuthCode } from "oauth-callback";
+
+const result = await getAuthCode(
+  "https://github.com/login/oauth/authorize?client_id=xxx",
+);
+console.log("Code:", result.code);
+```
+
+### MCP Integration
+
+```typescript
+import { browserAuth, fileStore } from "oauth-callback/mcp";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+
+const authProvider = browserAuth({
+  store: fileStore(),
+  scope: "read write",
+});
+
+const transport = new StreamableHTTPClientTransport(
+  new URL("https://mcp.example.com"),
+  { authProvider },
+);
+```
+
+### Error Handling
+
+```typescript
+import { getAuthCode, OAuthError } from "oauth-callback";
+
+try {
+  const result = await getAuthCode(authUrl);
+} catch (error) {
+  if (error instanceof OAuthError) {
+    console.error(`OAuth error: ${error.error}`);
+    console.error(`Details: ${error.error_description}`);
+  }
+}
+```
+
+### Custom Storage
+
+```typescript
+import { TokenStore, Tokens } from "oauth-callback/mcp";
+
+class RedisStore implements TokenStore {
+  async get(key: string): Promise<Tokens | null> {
+    // Implementation
+  }
+  async set(key: string, tokens: Tokens): Promise<void> {
+    // Implementation
+  }
+  // ... other methods
+}
+
+const authProvider = browserAuth({
+  store: new RedisStore(),
+});
+```
+
+## Security Considerations
+
+### Built-in Security Features
+
+- **PKCE by default** - Proof Key for Code Exchange enabled
+- **State validation** - Automatic CSRF protection
+- **Localhost-only binding** - Server only accepts local connections
+- **Automatic cleanup** - Server shuts down after callback
+- **Secure file permissions** - Mode 0600 for file storage
+
+### Best Practices
+
+```typescript
+// Always validate state for CSRF protection
+const state = crypto.randomUUID();
+const authUrl = `https://example.com/authorize?state=${state}&...`;
+const result = await getAuthCode(authUrl);
+if (result.state !== state) {
+  throw new Error("State mismatch - possible CSRF attack");
+}
+
+// Use ephemeral storage for maximum security
+const authProvider = browserAuth({
+  store: inMemoryStore(), // No disk persistence
+});
+
+// Implement PKCE for public clients
+const verifier = randomBytes(32).toString("base64url");
+const challenge = createHash("sha256").update(verifier).digest("base64url");
+```
+
+## Platform Support
+
+### Runtime Compatibility
+
+| Runtime | Minimum Version | Status             |
+| ------- | --------------- | ------------------ |
+| Node.js | 18.0.0          | ✅ Fully supported |
+| Deno    | 1.0.0           | ✅ Fully supported |
+| Bun     | 1.0.0           | ✅ Fully supported |
+
+### OAuth Provider Compatibility
+
+OAuth Callback works with any OAuth 2.0 provider that supports the authorization code flow:
+
+- ✅ GitHub
+- ✅ Google
+- ✅ Microsoft
+- ✅ Notion (with DCR)
+- ✅ Linear
+- ✅ Any RFC 6749 compliant provider
+
+### Browser Compatibility
+
+The library opens the user's default browser for authorization. All modern browsers are supported:
+
+- ✅ Chrome/Chromium
+- ✅ Firefox
+- ✅ Safari
+- ✅ Edge
+- ✅ Any browser that handles `http://localhost` URLs
+
+## Advanced Features
+
+### Dynamic Client Registration
+
+Automatically register OAuth clients without pre-configuration:
+
+```typescript
+// No client_id or client_secret needed!
+const authProvider = browserAuth({
+  scope: "read write",
+  store: fileStore(),
+});
+```
+
+### Multi-Environment Support
+
+```typescript
+function createAuthProvider(env: "dev" | "staging" | "prod") {
+  const configs = {
+    dev: { port: 3000, store: inMemoryStore() },
+    staging: { port: 3001, store: fileStore("~/.mcp/staging.json") },
+    prod: { port: 3002, store: fileStore("~/.mcp/prod.json") },
+  };
+  return browserAuth(configs[env]);
+}
+```
+
+### Request Logging
+
+```typescript
+const authProvider = browserAuth({
+  onRequest: (req) => {
+    const url = new URL(req.url);
+    console.log(`[OAuth] ${req.method} ${url.pathname}`);
+  },
+});
+```
+
+## Migration Guides
+
+### From Manual OAuth Implementation
+
+```typescript
+// Before: Manual OAuth flow
+const server = http.createServer();
+server.listen(3000);
+// ... complex callback handling ...
+
+// After: Using OAuth Callback
+const result = await getAuthCode(authUrl);
+```
+
+### To MCP Integration
+
+```typescript
+// Before: Custom OAuth provider
+class CustomOAuthProvider {
+  /* ... */
+}
+
+// After: Using browserAuth
+const authProvider = browserAuth({ store: fileStore() });
+```
+
+## API Stability
+
+| API             | Status | Since  | Notes                         |
+| --------------- | ------ | ------ | ----------------------------- |
+| `getAuthCode`   | Stable | v1.0.0 | Core API, backward compatible |
+| `browserAuth`   | Stable | v2.0.0 | MCP integration               |
+| `OAuthError`    | Stable | v1.0.0 | Error handling                |
+| `inMemoryStore` | Stable | v2.0.0 | Storage provider              |
+| `fileStore`     | Stable | v2.0.0 | Storage provider              |
+| Types           | Stable | v1.0.0 | TypeScript definitions        |
+
+## Related Resources
+
+- [Core Concepts](/core-concepts) - Architecture and design patterns
+- [Getting Started](/getting-started) - Quick start guide
+- [GitHub Repository](https://github.com/kriasoft/oauth-callback) - Source code and issues

--- a/docs/api/oauth-error.md
+++ b/docs/api/oauth-error.md
@@ -1,0 +1,564 @@
+---
+title: OAuthError
+description: OAuth-specific error class for handling authorization failures and provider errors according to RFC 6749.
+---
+
+# OAuthError
+
+The `OAuthError` class represents OAuth-specific errors that occur during the authorization flow. It extends the standard JavaScript `Error` class and provides structured access to OAuth error details as defined in [RFC 6749 Section 4.1.2.1](https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.2.1).
+
+## Class Definition
+
+```typescript
+class OAuthError extends Error {
+  error: string; // OAuth error code
+  error_description?: string; // Human-readable description
+  error_uri?: string; // URI with more information
+
+  constructor(error: string, description?: string, uri?: string);
+}
+```
+
+## Properties
+
+| Property            | Type                  | Description                                      |
+| ------------------- | --------------------- | ------------------------------------------------ |
+| `name`              | `string`              | Always `"OAuthError"` for instanceof checks      |
+| `error`             | `string`              | OAuth error code (e.g., `"access_denied"`)       |
+| `error_description` | `string \| undefined` | Human-readable error description                 |
+| `error_uri`         | `string \| undefined` | URI with additional error information            |
+| `message`           | `string`              | Inherited from Error (description or error code) |
+| `stack`             | `string`              | Inherited stack trace from Error                 |
+
+## OAuth Error Codes
+
+According to [RFC 6749](https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.2.1) and common provider extensions:
+
+### Standard OAuth 2.0 Error Codes
+
+| Error Code                  | Description                                         | User Action Required        |
+| --------------------------- | --------------------------------------------------- | --------------------------- |
+| `invalid_request`           | Request is missing required parameters or malformed | Fix request parameters      |
+| `unauthorized_client`       | Client not authorized for this grant type           | Check client configuration  |
+| `access_denied`             | User denied the authorization request               | User must approve access    |
+| `unsupported_response_type` | Response type not supported                         | Use supported response type |
+| `invalid_scope`             | Requested scope is invalid or unknown               | Request valid scopes        |
+| `server_error`              | Authorization server error (500)                    | Retry later                 |
+| `temporarily_unavailable`   | Server temporarily overloaded (503)                 | Retry with backoff          |
+
+### Common Provider Extensions
+
+| Error Code                   | Provider         | Description                    |
+| ---------------------------- | ---------------- | ------------------------------ |
+| `consent_required`           | Microsoft        | User consent needed            |
+| `interaction_required`       | Microsoft        | User interaction needed        |
+| `login_required`             | Google/Microsoft | User must authenticate         |
+| `account_selection_required` | Microsoft        | User must select account       |
+| `invalid_client`             | Various          | Client authentication failed   |
+| `invalid_grant`              | Various          | Grant or refresh token invalid |
+
+## Basic Usage
+
+### Catching OAuth Errors
+
+```typescript
+import { getAuthCode, OAuthError } from "oauth-callback";
+
+try {
+  const result = await getAuthCode(authorizationUrl);
+  console.log("Success! Code:", result.code);
+} catch (error) {
+  if (error instanceof OAuthError) {
+    console.error(`OAuth error: ${error.error}`);
+    if (error.error_description) {
+      console.error(`Details: ${error.error_description}`);
+    }
+    if (error.error_uri) {
+      console.error(`More info: ${error.error_uri}`);
+    }
+  } else {
+    // Handle other errors (timeout, network, etc.)
+    console.error("Unexpected error:", error);
+  }
+}
+```
+
+### Type Guard
+
+```typescript
+function isOAuthError(error: unknown): error is OAuthError {
+  return error instanceof OAuthError;
+}
+
+// Usage
+catch (error) {
+  if (isOAuthError(error)) {
+    // TypeScript knows error is OAuthError
+    handleOAuthError(error.error, error.error_description);
+  }
+}
+```
+
+## Error Handling Patterns
+
+### Comprehensive Error Handler
+
+```typescript
+import { OAuthError } from "oauth-callback";
+
+async function handleOAuthFlow(authUrl: string) {
+  try {
+    const result = await getAuthCode(authUrl);
+    return result.code;
+  } catch (error) {
+    if (error instanceof OAuthError) {
+      switch (error.error) {
+        case "access_denied":
+          // User cancelled - this is expected
+          console.log("User cancelled authorization");
+          return null;
+
+        case "invalid_scope":
+          throw new Error(
+            `Invalid permissions requested: ${error.error_description}`,
+          );
+
+        case "server_error":
+        case "temporarily_unavailable":
+          // Retry with exponential backoff
+          console.warn("Server error, retrying...");
+          await delay(1000);
+          return handleOAuthFlow(authUrl);
+
+        case "unauthorized_client":
+          throw new Error(
+            "Application not authorized. Please check OAuth app settings.",
+          );
+
+        default:
+          // Unknown OAuth error
+          throw new Error(
+            `OAuth authorization failed: ${error.error_description || error.error}`,
+          );
+      }
+    }
+
+    // Non-OAuth errors
+    throw error;
+  }
+}
+```
+
+### User-Friendly Error Messages
+
+```typescript
+function getErrorMessage(error: OAuthError): string {
+  const messages: Record<string, string> = {
+    access_denied: "You cancelled the authorization. Please try again when ready.",
+    invalid_scope: "The requested permissions are not available.",
+    server_error: "The authorization server encountered an error. Please try again.",
+    temporarily_unavailable: "The service is temporarily unavailable. Please try again later.",
+    unauthorized_client: "This application is not authorized. Please contact support.",
+    invalid_request: "The authorization request was invalid. Please try again.",
+    consent_required: "Please provide consent to continue.",
+    login_required: "Please log in to continue.",
+    interaction_required: "Additional interaction is required. Please complete the authorization in your browser."
+  };
+
+  return messages[error.error] ||
+    error.error_description ||
+    `Authorization failed: ${error.error}`;
+}
+
+// Usage
+catch (error) {
+  if (error instanceof OAuthError) {
+    const userMessage = getErrorMessage(error);
+    showUserNotification(userMessage);
+  }
+}
+```
+
+### Retry Logic
+
+```typescript
+async function authorizeWithRetry(
+  authUrl: string,
+  maxAttempts = 3,
+): Promise<string> {
+  let lastError: Error | undefined;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      const result = await getAuthCode(authUrl);
+      return result.code;
+    } catch (error) {
+      lastError = error as Error;
+
+      if (error instanceof OAuthError) {
+        // Don't retry user-actionable errors
+        if (
+          ["access_denied", "invalid_scope", "unauthorized_client"].includes(
+            error.error,
+          )
+        ) {
+          throw error;
+        }
+
+        // Retry server errors
+        if (["server_error", "temporarily_unavailable"].includes(error.error)) {
+          const delay = Math.min(1000 * Math.pow(2, attempt - 1), 10000);
+          console.warn(`Attempt ${attempt} failed, retrying in ${delay}ms...`);
+          await new Promise((resolve) => setTimeout(resolve, delay));
+          continue;
+        }
+      }
+
+      // Don't retry other errors
+      throw error;
+    }
+  }
+
+  throw lastError || new Error("Authorization failed after retries");
+}
+```
+
+## Error Recovery Strategies
+
+### Graceful Degradation
+
+```typescript
+class OAuthService {
+  private cachedToken?: string;
+
+  async getAccessToken(): Promise<string | null> {
+    try {
+      // Try to get fresh token
+      const code = await getAuthCode(this.authUrl);
+      const token = await this.exchangeCodeForToken(code);
+      this.cachedToken = token;
+      return token;
+    } catch (error) {
+      if (error instanceof OAuthError) {
+        if (error.error === "access_denied") {
+          // User cancelled - try using cached token if available
+          if (this.cachedToken) {
+            console.log("Using cached token after user cancellation");
+            return this.cachedToken;
+          }
+          return null;
+        }
+
+        if (error.error === "temporarily_unavailable" && this.cachedToken) {
+          // Service down - use cached token
+          console.warn("OAuth service unavailable, using cached token");
+          return this.cachedToken;
+        }
+      }
+
+      throw error;
+    }
+  }
+}
+```
+
+### Error Logging
+
+```typescript
+import { OAuthError } from "oauth-callback";
+
+function logOAuthError(error: OAuthError, context: Record<string, any>) {
+  const errorLog = {
+    timestamp: new Date().toISOString(),
+    type: "oauth_error",
+    error_code: error.error,
+    error_description: error.error_description,
+    error_uri: error.error_uri,
+    context,
+    stack: error.stack
+  };
+
+  // Send to logging service
+  if (["server_error", "temporarily_unavailable"].includes(error.error)) {
+    console.error("OAuth provider error:", errorLog);
+    // Report to monitoring service
+    reportToMonitoring(errorLog);
+  } else {
+    console.warn("OAuth user error:", errorLog);
+    // Track user analytics
+    trackUserEvent("oauth_error", { code: error.error });
+  }
+}
+
+// Usage
+catch (error) {
+  if (error instanceof OAuthError) {
+    logOAuthError(error, {
+      provider: "github",
+      client_id: CLIENT_ID,
+      scopes: ["user:email", "repo"]
+    });
+  }
+}
+```
+
+## Testing OAuth Errors
+
+### Unit Testing
+
+```typescript
+import { OAuthError } from "oauth-callback";
+import { describe, it, expect } from "vitest";
+
+describe("OAuthError", () => {
+  it("should create error with all properties", () => {
+    const error = new OAuthError(
+      "invalid_scope",
+      "The requested scope is invalid",
+      "https://example.com/docs/scopes",
+    );
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toBeInstanceOf(OAuthError);
+    expect(error.name).toBe("OAuthError");
+    expect(error.error).toBe("invalid_scope");
+    expect(error.error_description).toBe("The requested scope is invalid");
+    expect(error.error_uri).toBe("https://example.com/docs/scopes");
+    expect(error.message).toBe("The requested scope is invalid");
+  });
+
+  it("should use error code as message when description is missing", () => {
+    const error = new OAuthError("access_denied");
+    expect(error.message).toBe("access_denied");
+  });
+});
+```
+
+### Mock OAuth Errors
+
+```typescript
+import { OAuthError } from "oauth-callback";
+
+class MockOAuthProvider {
+  private shouldFail: string | null = null;
+
+  simulateError(errorCode: string) {
+    this.shouldFail = errorCode;
+  }
+
+  async authorize(): Promise<string> {
+    if (this.shouldFail) {
+      throw new OAuthError(
+        this.shouldFail,
+        this.getErrorDescription(this.shouldFail),
+        "https://example.com/oauth/errors",
+      );
+    }
+    return "mock_auth_code";
+  }
+
+  private getErrorDescription(code: string): string {
+    const descriptions: Record<string, string> = {
+      access_denied: "User denied access to the application",
+      invalid_scope: "One or more scopes are invalid",
+      server_error: "Authorization server encountered an error",
+    };
+    return descriptions[code] || "Unknown error";
+  }
+}
+
+// Usage in tests
+describe("OAuth Flow", () => {
+  it("should handle access_denied error", async () => {
+    const provider = new MockOAuthProvider();
+    provider.simulateError("access_denied");
+
+    await expect(provider.authorize()).rejects.toThrow(OAuthError);
+    await expect(provider.authorize()).rejects.toThrow("User denied access");
+  });
+});
+```
+
+## Integration with MCP
+
+When using with the MCP SDK through `browserAuth()`:
+
+```typescript
+import { browserAuth } from "oauth-callback/mcp";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+
+async function connectWithErrorHandling() {
+  const authProvider = browserAuth({
+    store: fileStore(),
+    onRequest: (req) => {
+      // Log OAuth flow for debugging
+      console.log(`OAuth: ${req.url}`);
+    },
+  });
+
+  const client = new Client(
+    { name: "my-app", version: "1.0.0" },
+    { capabilities: {} },
+  );
+
+  try {
+    await client.connect(transport);
+  } catch (error) {
+    // OAuth errors from browserAuth are wrapped
+    if (error.message?.includes("OAuthError")) {
+      // Extract OAuth error details
+      const match = error.message.match(/OAuthError: (\w+)/);
+      if (match) {
+        const errorCode = match[1];
+        console.error(`OAuth failed with code: ${errorCode}`);
+
+        if (errorCode === "access_denied") {
+          console.log("User cancelled MCP authorization");
+          return null;
+        }
+      }
+    }
+    throw error;
+  }
+}
+```
+
+## Error Flow Diagram
+
+```mermaid
+flowchart TD
+    Start([User initiates OAuth]) --> Auth[Open authorization URL]
+    Auth --> Decision{User action}
+
+    Decision -->|Approves| Success[Return code]
+    Decision -->|Denies| Denied[OAuthError: access_denied]
+    Decision -->|Invalid scope| Scope[OAuthError: invalid_scope]
+    Decision -->|Timeout| Timeout[TimeoutError]
+
+    Auth --> ServerCheck{Server status}
+    ServerCheck -->|Error 500| ServerErr[OAuthError: server_error]
+    ServerCheck -->|Error 503| Unavailable[OAuthError: temporarily_unavailable]
+    ServerCheck -->|Invalid client| Unauthorized[OAuthError: unauthorized_client]
+
+    Denied --> Handle[Error Handler]
+    Scope --> Handle
+    ServerErr --> Retry{Retry?}
+    Unavailable --> Retry
+    Unauthorized --> Handle
+    Timeout --> Handle
+
+    Retry -->|Yes| Auth
+    Retry -->|No| Handle
+
+    Handle --> UserMessage[Show user message]
+    Success --> Complete([Complete])
+
+    style Denied fill:#f96
+    style Scope fill:#f96
+    style ServerErr fill:#fa6
+    style Unavailable fill:#fa6
+    style Unauthorized fill:#f96
+    style Timeout fill:#f96
+    style Success fill:#6f9
+```
+
+## Best Practices
+
+### 1. Always Check Error Type
+
+```typescript
+catch (error) {
+  if (error instanceof OAuthError) {
+    // Handle OAuth-specific errors
+  } else if (error.message === "Timeout waiting for callback") {
+    // Handle timeout
+  } else {
+    // Handle unexpected errors
+  }
+}
+```
+
+### 2. Log Errors Appropriately
+
+```typescript
+if (error instanceof OAuthError) {
+  if (error.error === "access_denied") {
+    // User action - info level
+    console.info("User cancelled OAuth flow");
+  } else if (
+    ["server_error", "temporarily_unavailable"].includes(error.error)
+  ) {
+    // Provider issue - error level
+    console.error("OAuth provider error:", error);
+  } else {
+    // Configuration issue - warning level
+    console.warn("OAuth configuration error:", error);
+  }
+}
+```
+
+### 3. Provide Clear User Feedback
+
+```typescript
+function getUserMessage(error: OAuthError): string {
+  // Prefer provider's description if available
+  if (error.error_description) {
+    return error.error_description;
+  }
+
+  // Fall back to generic messages
+  return userFriendlyMessages[error.error] || "Authorization failed";
+}
+```
+
+### 4. Handle Errors at the Right Level
+
+```typescript
+// Low level - preserve error details
+async function getOAuthCode(url: string) {
+  const result = await getAuthCode(url);
+  // Let OAuthError propagate up
+  return result.code;
+}
+
+// High level - translate to user actions
+async function authenticateUser() {
+  try {
+    const code = await getOAuthCode(authUrl);
+    return { success: true, code };
+  } catch (error) {
+    if (error instanceof OAuthError && error.error === "access_denied") {
+      return { success: false, cancelled: true };
+    }
+    return { success: false, error: error.message };
+  }
+}
+```
+
+## Related APIs
+
+- [`getAuthCode`](/api/get-auth-code) - Main function that throws OAuthError
+- [`browserAuth`](/api/browser-auth) - MCP provider that handles OAuth errors
+- [`TimeoutError`](#timeouterror) - Related timeout error class
+
+## TimeoutError
+
+The library also exports a `TimeoutError` class for timeout-specific failures:
+
+```typescript
+class TimeoutError extends Error {
+  name: "TimeoutError";
+  constructor(message?: string);
+}
+```
+
+Usage:
+
+```typescript
+catch (error) {
+  if (error instanceof TimeoutError) {
+    console.error("OAuth flow timed out");
+    // Suggest user tries again
+  }
+}
+```

--- a/docs/api/storage-providers.md
+++ b/docs/api/storage-providers.md
@@ -1,0 +1,875 @@
+---
+title: Storage Providers
+description: Token storage interfaces and implementations for persisting OAuth tokens, client credentials, and session state.
+---
+
+# Storage Providers
+
+Storage providers in OAuth Callback manage the persistence of OAuth tokens, client credentials, and session state. The library provides flexible storage interfaces with built-in implementations for both ephemeral and persistent storage, plus the ability to create custom storage backends.
+
+## Storage Interfaces
+
+OAuth Callback defines two storage interfaces for different levels of OAuth state management:
+
+### TokenStore Interface
+
+The basic `TokenStore` interface handles OAuth token persistence:
+
+```typescript
+interface TokenStore {
+  get(key: string): Promise<Tokens | null>;
+  set(key: string, tokens: Tokens): Promise<void>;
+  delete(key: string): Promise<void>;
+  clear(): Promise<void>;
+}
+```
+
+#### Tokens Type
+
+```typescript
+interface Tokens {
+  accessToken: string; // OAuth access token
+  refreshToken?: string; // Optional refresh token
+  expiresAt?: number; // Absolute expiry time (Unix ms)
+  scope?: string; // Space-delimited granted scopes
+}
+```
+
+### OAuthStore Interface
+
+The extended `OAuthStore` interface adds support for Dynamic Client Registration and session state:
+
+```typescript
+interface OAuthStore extends TokenStore {
+  getClient(key: string): Promise<ClientInfo | null>;
+  setClient(key: string, client: ClientInfo): Promise<void>;
+  getSession(key: string): Promise<OAuthSession | null>;
+  setSession(key: string, session: OAuthSession): Promise<void>;
+}
+```
+
+#### ClientInfo Type
+
+```typescript
+interface ClientInfo {
+  clientId: string; // OAuth client ID
+  clientSecret?: string; // OAuth client secret
+  clientIdIssuedAt?: number; // When client was registered
+  clientSecretExpiresAt?: number; // When secret expires
+}
+```
+
+#### OAuthSession Type
+
+```typescript
+interface OAuthSession {
+  codeVerifier?: string; // PKCE code verifier
+  state?: string; // OAuth state parameter
+}
+```
+
+## Built-in Storage Providers
+
+### inMemoryStore()
+
+Ephemeral storage that keeps tokens in memory. Tokens are lost when the process exits.
+
+```typescript
+function inMemoryStore(): TokenStore;
+```
+
+#### Usage
+
+```typescript
+import { browserAuth, inMemoryStore } from "oauth-callback/mcp";
+
+const authProvider = browserAuth({
+  store: inMemoryStore(),
+});
+```
+
+#### Characteristics
+
+| Feature         | Description                                |
+| --------------- | ------------------------------------------ |
+| **Persistence** | None - data lost on process exit           |
+| **Concurrency** | Thread-safe within process                 |
+| **Security**    | Maximum - no disk persistence              |
+| **Performance** | Fastest - no I/O operations                |
+| **Use Cases**   | Development, testing, short-lived sessions |
+
+#### Implementation Details
+
+```typescript
+// Internal implementation uses a Map
+const store = new Map<string, Tokens>();
+
+// All operations are synchronous but return Promises
+// for interface consistency
+```
+
+### fileStore()
+
+Persistent storage that saves tokens to a JSON file on disk.
+
+```typescript
+function fileStore(filepath?: string): TokenStore;
+```
+
+#### Parameters
+
+| Parameter  | Type     | Default              | Description                        |
+| ---------- | -------- | -------------------- | ---------------------------------- |
+| `filepath` | `string` | `~/.mcp/tokens.json` | Custom file path for token storage |
+
+#### Usage
+
+```typescript
+import { browserAuth, fileStore } from "oauth-callback/mcp";
+
+// Use default location (~/.mcp/tokens.json)
+const authProvider = browserAuth({
+  store: fileStore(),
+});
+
+// Use custom location
+const customAuth = browserAuth({
+  store: fileStore("/path/to/my-tokens.json"),
+});
+
+// Environment-specific storage
+const envAuth = browserAuth({
+  store: fileStore(`~/.myapp/${process.env.NODE_ENV}-tokens.json`),
+});
+```
+
+#### Characteristics
+
+| Feature         | Description                         |
+| --------------- | ----------------------------------- |
+| **Persistence** | Survives process restarts           |
+| **Concurrency** | ⚠️ Not safe across processes        |
+| **Security**    | File permissions (mode 0600)        |
+| **Performance** | File I/O on each operation          |
+| **Use Cases**   | Desktop apps, long-running services |
+
+#### File Format
+
+The file store saves tokens in JSON format:
+
+```json
+{
+  "mcp-tokens": {
+    "accessToken": "eyJhbGciOiJSUzI1NiIs...",
+    "refreshToken": "refresh_token_here",
+    "expiresAt": 1735689600000,
+    "scope": "read write"
+  },
+  "app-specific-key": {
+    "accessToken": "another_token",
+    "expiresAt": 1735693200000
+  }
+}
+```
+
+::: warning Concurrent Access
+The file store is not safe for concurrent access across multiple processes. If you need multi-process support, implement a custom storage provider with proper locking mechanisms.
+:::
+
+## Storage Key Management
+
+Storage keys namespace tokens for different applications or environments:
+
+### Single Application
+
+```typescript
+const authProvider = browserAuth({
+  store: fileStore(),
+  storeKey: "my-app", // Default: "mcp-tokens"
+});
+```
+
+### Multiple Applications
+
+```typescript
+// App 1
+const app1Auth = browserAuth({
+  store: fileStore(),
+  storeKey: "app1-tokens",
+});
+
+// App 2 (same file, different key)
+const app2Auth = browserAuth({
+  store: fileStore(),
+  storeKey: "app2-tokens",
+});
+```
+
+### Environment Separation
+
+```typescript
+const authProvider = browserAuth({
+  store: fileStore(),
+  storeKey: `${process.env.APP_NAME}-${process.env.NODE_ENV}`,
+});
+// Results in keys like: "myapp-dev", "myapp-staging", "myapp-prod"
+```
+
+## Custom Storage Implementations
+
+Create custom storage providers by implementing the `TokenStore` or `OAuthStore` interface:
+
+### Basic Custom Storage
+
+#### Redis Storage Example
+
+```typescript
+import { TokenStore, Tokens } from "oauth-callback/mcp";
+import Redis from "ioredis";
+
+class RedisTokenStore implements TokenStore {
+  private redis: Redis;
+  private prefix: string;
+
+  constructor(redis: Redis, prefix = "oauth:") {
+    this.redis = redis;
+    this.prefix = prefix;
+  }
+
+  async get(key: string): Promise<Tokens | null> {
+    const data = await this.redis.get(this.prefix + key);
+    return data ? JSON.parse(data) : null;
+  }
+
+  async set(key: string, tokens: Tokens): Promise<void> {
+    const ttl = tokens.expiresAt
+      ? Math.floor((tokens.expiresAt - Date.now()) / 1000)
+      : undefined;
+
+    if (ttl && ttl > 0) {
+      await this.redis.setex(this.prefix + key, ttl, JSON.stringify(tokens));
+    } else {
+      await this.redis.set(this.prefix + key, JSON.stringify(tokens));
+    }
+  }
+
+  async delete(key: string): Promise<void> {
+    await this.redis.del(this.prefix + key);
+  }
+
+  async clear(): Promise<void> {
+    const keys = await this.redis.keys(this.prefix + "*");
+    if (keys.length > 0) {
+      await this.redis.del(...keys);
+    }
+  }
+}
+
+// Usage
+const redis = new Redis();
+const authProvider = browserAuth({
+  store: new RedisTokenStore(redis),
+});
+```
+
+#### SQLite Storage Example
+
+```typescript
+import { TokenStore, Tokens } from "oauth-callback/mcp";
+import Database from "better-sqlite3";
+
+class SQLiteTokenStore implements TokenStore {
+  private db: Database.Database;
+
+  constructor(dbPath = "./tokens.db") {
+    this.db = new Database(dbPath);
+    this.init();
+  }
+
+  private init() {
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS tokens (
+        key TEXT PRIMARY KEY,
+        access_token TEXT NOT NULL,
+        refresh_token TEXT,
+        expires_at INTEGER,
+        scope TEXT,
+        updated_at INTEGER DEFAULT (unixepoch())
+      )
+    `);
+  }
+
+  async get(key: string): Promise<Tokens | null> {
+    const row = this.db.prepare("SELECT * FROM tokens WHERE key = ?").get(key);
+
+    if (!row) return null;
+
+    return {
+      accessToken: row.access_token,
+      refreshToken: row.refresh_token,
+      expiresAt: row.expires_at,
+      scope: row.scope,
+    };
+  }
+
+  async set(key: string, tokens: Tokens): Promise<void> {
+    this.db
+      .prepare(
+        `
+      INSERT OR REPLACE INTO tokens 
+      (key, access_token, refresh_token, expires_at, scope)
+      VALUES (?, ?, ?, ?, ?)
+    `,
+      )
+      .run(
+        key,
+        tokens.accessToken,
+        tokens.refreshToken,
+        tokens.expiresAt,
+        tokens.scope,
+      );
+  }
+
+  async delete(key: string): Promise<void> {
+    this.db.prepare("DELETE FROM tokens WHERE key = ?").run(key);
+  }
+
+  async clear(): Promise<void> {
+    this.db.prepare("DELETE FROM tokens").run();
+  }
+}
+
+// Usage
+const authProvider = browserAuth({
+  store: new SQLiteTokenStore("./oauth-tokens.db"),
+});
+```
+
+### Advanced Custom Storage
+
+#### Full OAuthStore Implementation
+
+```typescript
+import {
+  OAuthStore,
+  Tokens,
+  ClientInfo,
+  OAuthSession,
+} from "oauth-callback/mcp";
+import { MongoClient, Db } from "mongodb";
+
+class MongoOAuthStore implements OAuthStore {
+  private db: Db;
+
+  constructor(db: Db) {
+    this.db = db;
+  }
+
+  // TokenStore methods
+  async get(key: string): Promise<Tokens | null> {
+    const doc = await this.db.collection("tokens").findOne({ _id: key });
+
+    return doc
+      ? {
+          accessToken: doc.accessToken,
+          refreshToken: doc.refreshToken,
+          expiresAt: doc.expiresAt,
+          scope: doc.scope,
+        }
+      : null;
+  }
+
+  async set(key: string, tokens: Tokens): Promise<void> {
+    await this.db
+      .collection("tokens")
+      .replaceOne(
+        { _id: key },
+        { _id: key, ...tokens, updatedAt: new Date() },
+        { upsert: true },
+      );
+  }
+
+  async delete(key: string): Promise<void> {
+    await this.db.collection("tokens").deleteOne({ _id: key });
+  }
+
+  async clear(): Promise<void> {
+    await this.db.collection("tokens").deleteMany({});
+  }
+
+  // OAuthStore additional methods
+  async getClient(key: string): Promise<ClientInfo | null> {
+    const doc = await this.db.collection("clients").findOne({ _id: key });
+
+    return doc
+      ? {
+          clientId: doc.clientId,
+          clientSecret: doc.clientSecret,
+          clientIdIssuedAt: doc.clientIdIssuedAt,
+          clientSecretExpiresAt: doc.clientSecretExpiresAt,
+        }
+      : null;
+  }
+
+  async setClient(key: string, client: ClientInfo): Promise<void> {
+    await this.db
+      .collection("clients")
+      .replaceOne(
+        { _id: key },
+        { _id: key, ...client, updatedAt: new Date() },
+        { upsert: true },
+      );
+  }
+
+  async getSession(key: string): Promise<OAuthSession | null> {
+    const doc = await this.db.collection("sessions").findOne({ _id: key });
+
+    return doc
+      ? {
+          codeVerifier: doc.codeVerifier,
+          state: doc.state,
+        }
+      : null;
+  }
+
+  async setSession(key: string, session: OAuthSession): Promise<void> {
+    await this.db
+      .collection("sessions")
+      .replaceOne(
+        { _id: key },
+        { _id: key, ...session, updatedAt: new Date() },
+        { upsert: true },
+      );
+  }
+}
+
+// Usage
+const client = new MongoClient("mongodb://localhost:27017");
+await client.connect();
+const db = client.db("oauth");
+
+const authProvider = browserAuth({
+  store: new MongoOAuthStore(db),
+});
+```
+
+## Storage Security
+
+### Encryption at Rest
+
+Implement encryption for sensitive token storage:
+
+```typescript
+import { TokenStore, Tokens } from "oauth-callback/mcp";
+import { createCipheriv, createDecipheriv, randomBytes, scrypt } from "crypto";
+import { promisify } from "util";
+
+class EncryptedTokenStore implements TokenStore {
+  private store: TokenStore;
+  private key: Buffer;
+
+  constructor(store: TokenStore, password: string) {
+    this.store = store;
+  }
+
+  async init(password: string) {
+    // Derive key from password
+    const salt = randomBytes(16);
+    this.key = (await promisify(scrypt)(password, salt, 32)) as Buffer;
+  }
+
+  private encrypt(data: string): string {
+    const iv = randomBytes(16);
+    const cipher = createCipheriv("aes-256-gcm", this.key, iv);
+
+    let encrypted = cipher.update(data, "utf8", "hex");
+    encrypted += cipher.final("hex");
+
+    const authTag = cipher.getAuthTag();
+
+    return JSON.stringify({
+      iv: iv.toString("hex"),
+      authTag: authTag.toString("hex"),
+      encrypted,
+    });
+  }
+
+  private decrypt(encryptedData: string): string {
+    const { iv, authTag, encrypted } = JSON.parse(encryptedData);
+
+    const decipher = createDecipheriv(
+      "aes-256-gcm",
+      this.key,
+      Buffer.from(iv, "hex"),
+    );
+
+    decipher.setAuthTag(Buffer.from(authTag, "hex"));
+
+    let decrypted = decipher.update(encrypted, "hex", "utf8");
+    decrypted += decipher.final("utf8");
+
+    return decrypted;
+  }
+
+  async get(key: string): Promise<Tokens | null> {
+    const encrypted = await this.store.get(key);
+    if (!encrypted) return null;
+
+    try {
+      const decrypted = this.decrypt(JSON.stringify(encrypted));
+      return JSON.parse(decrypted);
+    } catch {
+      return null; // Decryption failed
+    }
+  }
+
+  async set(key: string, tokens: Tokens): Promise<void> {
+    const encrypted = this.encrypt(JSON.stringify(tokens));
+    await this.store.set(key, JSON.parse(encrypted));
+  }
+
+  async delete(key: string): Promise<void> {
+    await this.store.delete(key);
+  }
+
+  async clear(): Promise<void> {
+    await this.store.clear();
+  }
+}
+
+// Usage
+const encryptedStore = new EncryptedTokenStore(
+  fileStore(),
+  process.env.ENCRYPTION_PASSWORD!,
+);
+await encryptedStore.init(process.env.ENCRYPTION_PASSWORD!);
+
+const authProvider = browserAuth({
+  store: encryptedStore,
+});
+```
+
+### Secure File Permissions
+
+When using file storage, ensure proper permissions:
+
+```typescript
+import { chmod } from "fs/promises";
+
+class SecureFileStore implements TokenStore {
+  private store: TokenStore;
+  private filepath: string;
+
+  constructor(filepath: string) {
+    this.filepath = filepath;
+    this.store = fileStore(filepath);
+  }
+
+  async set(key: string, tokens: Tokens): Promise<void> {
+    await this.store.set(key, tokens);
+    // Ensure file is only readable by owner
+    await chmod(this.filepath, 0o600);
+  }
+
+  // ... other methods delegate to store
+}
+```
+
+## Storage Patterns
+
+### Multi-Tenant Storage
+
+Support multiple tenants with isolated storage:
+
+```typescript
+class TenantAwareStore implements TokenStore {
+  private stores = new Map<string, TokenStore>();
+
+  getStore(tenantId: string): TokenStore {
+    if (!this.stores.has(tenantId)) {
+      this.stores.set(tenantId, fileStore(`~/.oauth/${tenantId}/tokens.json`));
+    }
+    return this.stores.get(tenantId)!;
+  }
+
+  async get(key: string): Promise<Tokens | null> {
+    const [tenantId, tokenKey] = key.split(":");
+    return this.getStore(tenantId).get(tokenKey);
+  }
+
+  async set(key: string, tokens: Tokens): Promise<void> {
+    const [tenantId, tokenKey] = key.split(":");
+    return this.getStore(tenantId).set(tokenKey, tokens);
+  }
+
+  // ... other methods
+}
+
+// Usage
+const authProvider = browserAuth({
+  store: new TenantAwareStore(),
+  storeKey: `${tenantId}:${appName}`,
+});
+```
+
+### Cached Storage
+
+Add caching layer for performance:
+
+```typescript
+class CachedTokenStore implements TokenStore {
+  private cache = new Map<string, { tokens: Tokens; expires: number }>();
+  private store: TokenStore;
+  private ttl: number;
+
+  constructor(store: TokenStore, ttlSeconds = 300) {
+    this.store = store;
+    this.ttl = ttlSeconds * 1000;
+  }
+
+  async get(key: string): Promise<Tokens | null> {
+    // Check cache first
+    const cached = this.cache.get(key);
+    if (cached && Date.now() < cached.expires) {
+      return cached.tokens;
+    }
+
+    // Load from store
+    const tokens = await this.store.get(key);
+    if (tokens) {
+      this.cache.set(key, {
+        tokens,
+        expires: Date.now() + this.ttl,
+      });
+    }
+
+    return tokens;
+  }
+
+  async set(key: string, tokens: Tokens): Promise<void> {
+    // Update both cache and store
+    this.cache.set(key, {
+      tokens,
+      expires: Date.now() + this.ttl,
+    });
+    await this.store.set(key, tokens);
+  }
+
+  async delete(key: string): Promise<void> {
+    this.cache.delete(key);
+    await this.store.delete(key);
+  }
+
+  async clear(): Promise<void> {
+    this.cache.clear();
+    await this.store.clear();
+  }
+}
+
+// Usage
+const authProvider = browserAuth({
+  store: new CachedTokenStore(fileStore(), 600), // 10 min cache
+});
+```
+
+## Testing Storage Providers
+
+### Mock Storage for Tests
+
+```typescript
+import { TokenStore, Tokens } from "oauth-callback/mcp";
+
+class MockTokenStore implements TokenStore {
+  private data = new Map<string, Tokens>();
+  public getCalls: string[] = [];
+  public setCalls: Array<{ key: string; tokens: Tokens }> = [];
+
+  async get(key: string): Promise<Tokens | null> {
+    this.getCalls.push(key);
+    return this.data.get(key) ?? null;
+  }
+
+  async set(key: string, tokens: Tokens): Promise<void> {
+    this.setCalls.push({ key, tokens });
+    this.data.set(key, tokens);
+  }
+
+  async delete(key: string): Promise<void> {
+    this.data.delete(key);
+  }
+
+  async clear(): Promise<void> {
+    this.data.clear();
+  }
+
+  // Test helper methods
+  reset() {
+    this.data.clear();
+    this.getCalls = [];
+    this.setCalls = [];
+  }
+
+  setTestData(key: string, tokens: Tokens) {
+    this.data.set(key, tokens);
+  }
+}
+
+// Usage in tests
+describe("OAuth Flow", () => {
+  let mockStore: MockTokenStore;
+
+  beforeEach(() => {
+    mockStore = new MockTokenStore();
+    mockStore.setTestData("test-key", {
+      accessToken: "test-token",
+      expiresAt: Date.now() + 3600000,
+    });
+  });
+
+  it("should use stored tokens", async () => {
+    const authProvider = browserAuth({
+      store: mockStore,
+      storeKey: "test-key",
+    });
+
+    // Test your OAuth flow
+    expect(mockStore.getCalls).toContain("test-key");
+  });
+});
+```
+
+## Migration Strategies
+
+### Migrating Storage Backends
+
+```typescript
+async function migrateStorage(
+  source: TokenStore,
+  target: TokenStore,
+  keys?: string[],
+) {
+  // If no keys specified, migrate all (if source supports listing)
+  const keysToMigrate = keys || ["mcp-tokens"]; // Default key
+
+  for (const key of keysToMigrate) {
+    const tokens = await source.get(key);
+    if (tokens) {
+      await target.set(key, tokens);
+      console.log(`Migrated tokens for key: ${key}`);
+    }
+  }
+
+  console.log("Migration complete");
+}
+
+// Example: Migrate from file to Redis
+const fileStorage = fileStore();
+const redisStorage = new RedisTokenStore(redis);
+
+await migrateStorage(fileStorage, redisStorage);
+```
+
+### Upgrading Token Format
+
+```typescript
+class LegacyAdapter implements TokenStore {
+  private store: TokenStore;
+
+  constructor(store: TokenStore) {
+    this.store = store;
+  }
+
+  async get(key: string): Promise<Tokens | null> {
+    const data = await this.store.get(key);
+    if (!data) return null;
+
+    // Handle legacy format
+    if ("access_token" in (data as any)) {
+      return {
+        accessToken: (data as any).access_token,
+        refreshToken: (data as any).refresh_token,
+        expiresAt: (data as any).expires_at,
+        scope: (data as any).scope,
+      };
+    }
+
+    return data;
+  }
+
+  // ... other methods
+}
+```
+
+## Best Practices
+
+### Choosing a Storage Provider
+
+| Scenario               | Recommended Storage   | Reason                |
+| ---------------------- | --------------------- | --------------------- |
+| Development/Testing    | `inMemoryStore()`     | No persistence needed |
+| CLI Tools (single-use) | `inMemoryStore()`     | Security, simplicity  |
+| Desktop Apps           | `fileStore()`         | User convenience      |
+| Server Applications    | Custom (Redis/DB)     | Scalability, sharing  |
+| High Security          | `inMemoryStore()`     | No disk persistence   |
+| Multi-tenant           | Custom implementation | Isolation required    |
+
+### Storage Key Conventions
+
+```typescript
+// Use hierarchical keys for organization
+const key = `${organization}:${application}:${environment}`;
+
+// Examples:
+("acme:billing-app:production");
+("acme:billing-app:staging");
+("personal:cli-tool:default");
+```
+
+### Error Handling
+
+Always handle storage failures gracefully:
+
+```typescript
+class ResilientTokenStore implements TokenStore {
+  private primary: TokenStore;
+  private fallback: TokenStore;
+
+  constructor(primary: TokenStore, fallback: TokenStore) {
+    this.primary = primary;
+    this.fallback = fallback;
+  }
+
+  async get(key: string): Promise<Tokens | null> {
+    try {
+      return await this.primary.get(key);
+    } catch (error) {
+      console.warn("Primary storage failed, using fallback:", error);
+      return await this.fallback.get(key);
+    }
+  }
+
+  async set(key: string, tokens: Tokens): Promise<void> {
+    try {
+      await this.primary.set(key, tokens);
+      // Also update fallback for consistency
+      await this.fallback.set(key, tokens).catch(() => {});
+    } catch (error) {
+      console.warn("Primary storage failed, using fallback:", error);
+      await this.fallback.set(key, tokens);
+    }
+  }
+
+  // ... other methods
+}
+
+// Usage: Redis with file fallback
+const authProvider = browserAuth({
+  store: new ResilientTokenStore(new RedisTokenStore(redis), fileStore()),
+});
+```
+
+## Related APIs
+
+- [`browserAuth`](/api/browser-auth) - OAuth provider using storage
+- [`TokenStore` Types](/api/types#tokenstore) - TypeScript interfaces
+- [`OAuthError`](/api/oauth-error) - Error handling

--- a/docs/api/types.md
+++ b/docs/api/types.md
@@ -1,0 +1,693 @@
+---
+title: TypeScript Types
+description: Complete reference for all TypeScript types, interfaces, and type definitions in the oauth-callback library.
+---
+
+# TypeScript Types
+
+OAuth Callback is fully typed with TypeScript, providing comprehensive type safety and excellent IDE support. This page documents all exported types and interfaces available in the library.
+
+## Type Organization
+
+```mermaid
+flowchart TB
+    subgraph "Core Types"
+        GetAuthCodeOptions
+        CallbackResult
+        ServerOptions
+        CallbackServer
+    end
+
+    subgraph "Error Types"
+        OAuthError
+        TimeoutError
+    end
+
+    subgraph "Storage Types"
+        TokenStore
+        OAuthStore
+        Tokens
+        ClientInfo
+        OAuthSession
+    end
+
+    subgraph "MCP Types"
+        BrowserAuthOptions
+        OAuthClientProvider["OAuthClientProvider (MCP SDK)"]
+    end
+
+    GetAuthCodeOptions --> CallbackResult
+    ServerOptions --> CallbackServer
+    BrowserAuthOptions --> TokenStore
+    BrowserAuthOptions --> OAuthStore
+    OAuthStore --> Tokens
+    OAuthStore --> ClientInfo
+    OAuthStore --> OAuthSession
+```
+
+## Core Types
+
+### GetAuthCodeOptions
+
+Configuration options for the `getAuthCode` function.
+
+```typescript
+interface GetAuthCodeOptions {
+  authorizationUrl: string; // OAuth authorization URL
+  port?: number; // Server port (default: 3000)
+  hostname?: string; // Hostname (default: "localhost")
+  callbackPath?: string; // Callback path (default: "/callback")
+  timeout?: number; // Timeout in ms (default: 30000)
+  openBrowser?: boolean; // Auto-open browser (default: true)
+  successHtml?: string; // Custom success HTML
+  errorHtml?: string; // Custom error HTML template
+  signal?: AbortSignal; // Cancellation signal
+  onRequest?: (req: Request) => void; // Request callback
+}
+```
+
+#### Usage Example
+
+```typescript
+import type { GetAuthCodeOptions } from "oauth-callback";
+
+const options: GetAuthCodeOptions = {
+  authorizationUrl: "https://oauth.example.com/authorize?...",
+  port: 8080,
+  timeout: 60000,
+  successHtml: "<h1>Success!</h1>",
+  errorHtml: "<h1>Error: {{error_description}}</h1>",
+  onRequest: (req) => console.log(`Request: ${req.url}`),
+};
+
+const result = await getAuthCode(options);
+```
+
+### CallbackResult
+
+Result object returned from OAuth callback containing authorization code or error details.
+
+```typescript
+interface CallbackResult {
+  code?: string; // Authorization code
+  state?: string; // State parameter for CSRF
+  error?: string; // OAuth error code
+  error_description?: string; // Error description
+  error_uri?: string; // Error info URI
+  [key: string]: string | undefined; // Additional params
+}
+```
+
+#### Usage Example
+
+```typescript
+import type { CallbackResult } from "oauth-callback";
+
+function handleCallback(result: CallbackResult) {
+  if (result.error) {
+    console.error(`OAuth error: ${result.error}`);
+    if (result.error_description) {
+      console.error(`Details: ${result.error_description}`);
+    }
+    return;
+  }
+
+  if (result.code) {
+    console.log(`Authorization code: ${result.code}`);
+
+    // Validate state for CSRF protection
+    if (result.state !== expectedState) {
+      throw new Error("State mismatch - possible CSRF attack");
+    }
+
+    // Exchange code for tokens
+    exchangeCodeForTokens(result.code);
+  }
+}
+```
+
+### ServerOptions
+
+Configuration options for the OAuth callback server.
+
+```typescript
+interface ServerOptions {
+  port: number; // Port to bind to
+  hostname?: string; // Hostname (default: "localhost")
+  successHtml?: string; // Custom success HTML
+  errorHtml?: string; // Error HTML template
+  signal?: AbortSignal; // Cancellation signal
+  onRequest?: (req: Request) => void; // Request callback
+}
+```
+
+#### Usage Example
+
+```typescript
+import type { ServerOptions } from "oauth-callback";
+
+const serverOptions: ServerOptions = {
+  port: 3000,
+  hostname: "127.0.0.1",
+  successHtml: `
+    <html>
+      <body>
+        <h1>Authorization successful!</h1>
+        <script>window.close()</script>
+      </body>
+    </html>
+  `,
+  onRequest: (req) => {
+    const url = new URL(req.url);
+    console.log(`[${req.method}] ${url.pathname}`);
+  },
+};
+```
+
+### CallbackServer
+
+Interface for OAuth callback server implementations across different runtimes.
+
+```typescript
+interface CallbackServer {
+  start(options: ServerOptions): Promise<void>;
+  waitForCallback(path: string, timeout: number): Promise<CallbackResult>;
+  stop(): Promise<void>;
+}
+```
+
+#### Implementation Example
+
+```typescript
+import type {
+  CallbackServer,
+  ServerOptions,
+  CallbackResult,
+} from "oauth-callback";
+
+class CustomCallbackServer implements CallbackServer {
+  private server?: HttpServer;
+
+  async start(options: ServerOptions): Promise<void> {
+    // Start HTTP server
+    this.server = await createServer(options);
+  }
+
+  async waitForCallback(
+    path: string,
+    timeout: number,
+  ): Promise<CallbackResult> {
+    // Wait for OAuth callback
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        reject(new Error("Timeout waiting for callback"));
+      }, timeout);
+
+      this.server.on("request", (req) => {
+        if (req.url.startsWith(path)) {
+          clearTimeout(timer);
+          const params = parseQueryParams(req.url);
+          resolve(params);
+        }
+      });
+    });
+  }
+
+  async stop(): Promise<void> {
+    // Stop server
+    await this.server?.close();
+  }
+}
+```
+
+## Storage Types
+
+### TokenStore
+
+Basic interface for OAuth token storage.
+
+```typescript
+interface TokenStore {
+  get(key: string): Promise<Tokens | null>;
+  set(key: string, tokens: Tokens): Promise<void>;
+  delete(key: string): Promise<void>;
+  clear(): Promise<void>;
+}
+```
+
+### Tokens
+
+OAuth token data structure.
+
+```typescript
+interface Tokens {
+  accessToken: string; // OAuth access token
+  refreshToken?: string; // Optional refresh token
+  expiresAt?: number; // Absolute expiry (Unix ms)
+  scope?: string; // Space-delimited scopes
+}
+```
+
+#### Usage Example
+
+```typescript
+import type { Tokens, TokenStore } from "oauth-callback/mcp";
+
+class CustomTokenStore implements TokenStore {
+  private storage = new Map<string, Tokens>();
+
+  async get(key: string): Promise<Tokens | null> {
+    return this.storage.get(key) ?? null;
+  }
+
+  async set(key: string, tokens: Tokens): Promise<void> {
+    // Check if token is expired
+    if (tokens.expiresAt && Date.now() >= tokens.expiresAt) {
+      console.warn("Storing expired token");
+    }
+    this.storage.set(key, tokens);
+  }
+
+  async delete(key: string): Promise<void> {
+    this.storage.delete(key);
+  }
+
+  async clear(): Promise<void> {
+    this.storage.clear();
+  }
+}
+```
+
+### OAuthStore
+
+Extended storage interface with Dynamic Client Registration support.
+
+```typescript
+interface OAuthStore extends TokenStore {
+  getClient(key: string): Promise<ClientInfo | null>;
+  setClient(key: string, client: ClientInfo): Promise<void>;
+  getSession(key: string): Promise<OAuthSession | null>;
+  setSession(key: string, session: OAuthSession): Promise<void>;
+}
+```
+
+### ClientInfo
+
+Dynamic client registration data.
+
+```typescript
+interface ClientInfo {
+  clientId: string; // OAuth client ID
+  clientSecret?: string; // Client secret
+  clientIdIssuedAt?: number; // Registration time
+  clientSecretExpiresAt?: number; // Secret expiry
+}
+```
+
+### OAuthSession
+
+Active OAuth flow state for crash recovery.
+
+```typescript
+interface OAuthSession {
+  codeVerifier?: string; // PKCE code verifier
+  state?: string; // OAuth state parameter
+}
+```
+
+#### Complete Storage Example
+
+```typescript
+import type {
+  OAuthStore,
+  Tokens,
+  ClientInfo,
+  OAuthSession,
+} from "oauth-callback/mcp";
+
+class DatabaseOAuthStore implements OAuthStore {
+  constructor(private db: Database) {}
+
+  // TokenStore methods
+  async get(key: string): Promise<Tokens | null> {
+    return await this.db.tokens.findOne({ key });
+  }
+
+  async set(key: string, tokens: Tokens): Promise<void> {
+    await this.db.tokens.upsert({ key }, tokens);
+  }
+
+  async delete(key: string): Promise<void> {
+    await this.db.tokens.delete({ key });
+  }
+
+  async clear(): Promise<void> {
+    await this.db.tokens.deleteMany({});
+  }
+
+  // OAuthStore additional methods
+  async getClient(key: string): Promise<ClientInfo | null> {
+    return await this.db.clients.findOne({ key });
+  }
+
+  async setClient(key: string, client: ClientInfo): Promise<void> {
+    // Check if client secret is expired
+    if (
+      client.clientSecretExpiresAt &&
+      Date.now() >= client.clientSecretExpiresAt
+    ) {
+      throw new Error("Cannot store expired client secret");
+    }
+    await this.db.clients.upsert({ key }, client);
+  }
+
+  async getSession(key: string): Promise<OAuthSession | null> {
+    return await this.db.sessions.findOne({ key });
+  }
+
+  async setSession(key: string, session: OAuthSession): Promise<void> {
+    await this.db.sessions.upsert({ key }, session);
+  }
+}
+```
+
+## MCP Types
+
+### BrowserAuthOptions
+
+Configuration for browser-based OAuth flows with MCP servers.
+
+```typescript
+interface BrowserAuthOptions {
+  // OAuth credentials
+  clientId?: string; // Pre-registered client ID
+  clientSecret?: string; // Pre-registered secret
+  scope?: string; // OAuth scopes
+
+  // Server configuration
+  port?: number; // Callback port (default: 3000)
+  hostname?: string; // Hostname (default: "localhost")
+  callbackPath?: string; // Path (default: "/callback")
+
+  // Storage
+  store?: TokenStore; // Token storage
+  storeKey?: string; // Storage key prefix
+
+  // Behavior
+  openBrowser?: boolean | string; // Browser control
+  authTimeout?: number; // Timeout ms (default: 300000)
+  usePKCE?: boolean; // Enable PKCE (default: true)
+
+  // UI
+  successHtml?: string; // Success page HTML
+  errorHtml?: string; // Error page template
+
+  // Debugging
+  onRequest?: (req: Request) => void; // Request logger
+}
+```
+
+#### Usage Example
+
+```typescript
+import type { BrowserAuthOptions } from "oauth-callback/mcp";
+import { browserAuth, fileStore } from "oauth-callback/mcp";
+
+const options: BrowserAuthOptions = {
+  // Dynamic Client Registration - no credentials needed
+  scope: "read write",
+
+  // Custom server configuration
+  port: 8080,
+  hostname: "127.0.0.1",
+
+  // Persistent storage
+  store: fileStore("~/.myapp/tokens.json"),
+  storeKey: "production",
+
+  // Security
+  usePKCE: true,
+  authTimeout: 600000, // 10 minutes
+
+  // Custom UI
+  successHtml: "<h1>Success!</h1>",
+
+  // Debugging
+  onRequest: (req) => {
+    console.log(`[OAuth] ${new URL(req.url).pathname}`);
+  },
+};
+
+const authProvider = browserAuth(options);
+```
+
+## Error Types
+
+### OAuthError
+
+OAuth-specific error class.
+
+```typescript
+class OAuthError extends Error {
+  name: "OAuthError";
+  error: string; // OAuth error code
+  error_description?: string; // Human-readable description
+  error_uri?: string; // Info URI
+
+  constructor(error: string, description?: string, uri?: string);
+}
+```
+
+### TimeoutError
+
+Timeout-specific error class.
+
+```typescript
+class TimeoutError extends Error {
+  name: "TimeoutError";
+  constructor(message?: string);
+}
+```
+
+#### Error Handling Example
+
+```typescript
+import { OAuthError, TimeoutError } from "oauth-callback";
+import type { CallbackResult } from "oauth-callback";
+
+function handleAuthResult(result: CallbackResult) {
+  // Check for OAuth errors in result
+  if (result.error) {
+    throw new OAuthError(
+      result.error,
+      result.error_description,
+      result.error_uri,
+    );
+  }
+
+  if (!result.code) {
+    throw new Error("No authorization code received");
+  }
+
+  return result.code;
+}
+
+// Usage with proper error handling
+try {
+  const code = await getAuthCode(authUrl);
+} catch (error) {
+  if (error instanceof OAuthError) {
+    console.error(`OAuth error: ${error.error}`);
+  } else if (error instanceof TimeoutError) {
+    console.error("Authorization timed out");
+  } else {
+    console.error("Unexpected error:", error);
+  }
+}
+```
+
+## Type Guards
+
+Useful type guard functions for runtime type checking:
+
+```typescript
+import type { Tokens, ClientInfo, OAuthSession } from "oauth-callback/mcp";
+
+// Check if object is Tokens
+function isTokens(obj: unknown): obj is Tokens {
+  return (
+    typeof obj === "object" &&
+    obj !== null &&
+    "accessToken" in obj &&
+    typeof (obj as any).accessToken === "string"
+  );
+}
+
+// Check if object is ClientInfo
+function isClientInfo(obj: unknown): obj is ClientInfo {
+  return (
+    typeof obj === "object" &&
+    obj !== null &&
+    "clientId" in obj &&
+    typeof (obj as any).clientId === "string"
+  );
+}
+
+// Check if object is OAuthSession
+function isOAuthSession(obj: unknown): obj is OAuthSession {
+  return (
+    typeof obj === "object" &&
+    obj !== null &&
+    ("codeVerifier" in obj || "state" in obj)
+  );
+}
+
+// Check if error is OAuthError
+function isOAuthError(error: unknown): error is OAuthError {
+  return error instanceof OAuthError;
+}
+
+// Usage
+const stored = await store.get("key");
+if (stored && isTokens(stored)) {
+  console.log("Valid tokens:", stored.accessToken);
+}
+```
+
+## Generic Type Patterns
+
+### Result Type Pattern
+
+```typescript
+type Result<T, E = Error> =
+  | { success: true; data: T }
+  | { success: false; error: E };
+
+async function safeGetAuthCode(
+  url: string,
+): Promise<Result<CallbackResult, OAuthError | Error>> {
+  try {
+    const result = await getAuthCode(url);
+    return { success: true, data: result };
+  } catch (error) {
+    if (error instanceof OAuthError) {
+      return { success: false, error };
+    }
+    return { success: false, error: error as Error };
+  }
+}
+
+// Usage
+const result = await safeGetAuthCode(authUrl);
+if (result.success) {
+  console.log("Code:", result.data.code);
+} else {
+  console.error("Error:", result.error.message);
+}
+```
+
+### Storage Adapter Pattern
+
+```typescript
+type StorageAdapter<T> = {
+  load(): Promise<T | null>;
+  save(data: T): Promise<void>;
+  remove(): Promise<void>;
+};
+
+function createStorageAdapter<T>(
+  store: TokenStore,
+  key: string,
+): StorageAdapter<T> {
+  return {
+    async load() {
+      const data = await store.get(key);
+      return data as T | null;
+    },
+    async save(data: T) {
+      await store.set(key, data as any);
+    },
+    async remove() {
+      await store.delete(key);
+    },
+  };
+}
+```
+
+## Type Exports
+
+### Main Package Exports
+
+```typescript
+// From "oauth-callback"
+export type {
+  GetAuthCodeOptions,
+  CallbackResult,
+  CallbackServer,
+  ServerOptions,
+};
+
+export { getAuthCode, OAuthError, inMemoryStore, fileStore };
+```
+
+### MCP Sub-Package Exports
+
+```typescript
+// From "oauth-callback/mcp"
+export type {
+  BrowserAuthOptions,
+  TokenStore,
+  OAuthStore,
+  Tokens,
+  ClientInfo,
+  OAuthSession,
+};
+
+export { browserAuth, inMemoryStore, fileStore };
+```
+
+### Namespace Export
+
+```typescript
+// Also available via namespace
+import { mcp } from "oauth-callback";
+
+// All MCP types and functions under mcp namespace
+const authProvider = mcp.browserAuth({
+  store: mcp.fileStore(),
+});
+```
+
+## TypeScript Configuration
+
+For optimal type support, use these TypeScript settings:
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node", "bun-types"]
+  }
+}
+```
+
+## Type Versioning
+
+The library follows semantic versioning for types:
+
+- **Major version**: Breaking type changes
+- **Minor version**: New types or optional properties
+- **Patch version**: Type fixes that don't break compatibility
+
+## Related Documentation
+
+- [`getAuthCode`](/api/get-auth-code) - Main function using these types
+- [`browserAuth`](/api/browser-auth) - MCP provider using these types
+- [`Storage Providers`](/api/storage-providers) - Storage type implementations
+- [`OAuthError`](/api/oauth-error) - Error type documentation

--- a/docs/core-concepts.md
+++ b/docs/core-concepts.md
@@ -1,0 +1,505 @@
+---
+title: Core Concepts
+description: Master the fundamental concepts and architecture of OAuth Callback, from the authorization flow to token management and MCP integration patterns.
+---
+
+# Core Concepts {#top}
+
+Understanding the core concepts behind **OAuth Callback** will help you build robust OAuth integrations in your CLI tools, desktop applications, and MCP clients. This page covers the fundamental patterns, architectural decisions, and key abstractions that power the library.
+
+## The Authorization Code Flow
+
+OAuth Callback implements the OAuth 2.0 Authorization Code Flow, the most secure flow for applications that can protect client secrets. This flow involves three key participants:
+
+```mermaid
+flowchart LR
+    A[Your App] -->|Step 1: Request authorization| B[Auth Server]
+    B -->|Step 2: User authenticates| C[User]
+    C -->|Step 3: Grants permission| B
+    B -->|Step 4: Returns code| A
+    A -->|Step 5: Exchange code| B
+    B -->|Step 6: Returns tokens| A
+```
+
+### Why Authorization Code Flow?
+
+The authorization code flow provides several security benefits:
+
+- **No token exposure**: Access tokens never pass through the browser
+- **Short-lived codes**: Authorization codes expire quickly (typically 10 minutes)
+- **Server verification**: The auth server can verify the client's identity
+- **Refresh capability**: Supports refresh tokens for long-lived access
+
+## The Localhost Callback Pattern
+
+The core innovation of OAuth Callback is making the localhost callback pattern trivially simple to implement. This pattern, standardized in [RFC 8252](https://www.rfc-editor.org/rfc/rfc8252.html), solves a fundamental problem: how can native applications receive OAuth callbacks without a public web server?
+
+### The Problem
+
+Traditional web applications have public URLs where OAuth providers can send callbacks:
+
+```
+https://myapp.com/oauth/callback?code=xyz123
+```
+
+But CLI tools and desktop apps don't have public URLs. They run on the user's machine behind firewalls and NAT.
+
+### The Solution
+
+OAuth Callback creates a temporary HTTP server on localhost that:
+
+1. **Binds locally**: Only accepts connections from `127.0.0.1`
+2. **Uses dynamic ports**: Works with any available port
+3. **Auto-terminates**: Shuts down after receiving the callback
+4. **Handles edge cases**: Timeouts, errors, user cancellation
+
+```typescript
+// This single function handles all the complexity
+const result = await getAuthCode(authorizationUrl);
+```
+
+## Architecture Overview
+
+OAuth Callback is built on a layered architecture that separates concerns and enables flexibility:
+
+```mermaid
+flowchart TD
+    subgraph "Application Layer"
+        A[Your CLI/Desktop App]
+    end
+
+    subgraph "OAuth Callback Library"
+        B[getAuthCode Function]
+        C[HTTP Server Module]
+        D[Browser Launcher]
+        E[Error Handler]
+        F[Template Engine]
+    end
+
+    subgraph "MCP Integration Layer"
+        G[browserAuth Provider]
+        H[Token Storage]
+        I[Dynamic Client Registration]
+    end
+
+    A --> B
+    B --> C
+    B --> D
+    B --> E
+    B --> F
+    A --> G
+    G --> H
+    G --> I
+```
+
+### Core Components
+
+#### 1. The HTTP Server (`server.ts`)
+
+The heart of OAuth Callback is a lightweight HTTP server that:
+
+- Listens on localhost for the OAuth callback
+- Parses query parameters from the redirect
+- Serves success/error HTML pages
+- Implements proper cleanup on completion
+
+```typescript
+// Internally, the server handles:
+- Request routing (/callback path matching)
+- Query parameter extraction (code, state, error)
+- HTML template rendering with placeholders
+- Graceful shutdown after callback
+```
+
+#### 2. The Authorization Handler (`getAuthCode`)
+
+The main API surface that orchestrates the entire flow:
+
+```typescript
+interface GetAuthCodeOptions {
+  authorizationUrl: string; // OAuth provider URL
+  port?: number; // Server port (default: 3000)
+  timeout?: number; // Timeout in ms (default: 30000)
+  openBrowser?: boolean; // Auto-open browser (default: true)
+  signal?: AbortSignal; // For cancellation
+  // ... more options
+}
+```
+
+#### 3. Error Management (`OAuthError`)
+
+Specialized error handling for OAuth-specific failures:
+
+```typescript
+class OAuthError extends Error {
+  error: string; // OAuth error code
+  error_description?: string; // Human-readable description
+  error_uri?: string; // Link to more information
+}
+```
+
+Common OAuth errors are properly typed and handled:
+
+- `access_denied` - User declined authorization
+- `invalid_scope` - Requested scope is invalid
+- `server_error` - Authorization server error
+- `temporarily_unavailable` - Server is overloaded
+
+## Token Management
+
+For applications that need to persist OAuth tokens, OAuth Callback provides a flexible storage abstraction:
+
+### Storage Abstraction
+
+The `TokenStore` interface enables different storage strategies:
+
+```typescript
+interface TokenStore {
+  get(key: string): Promise<Tokens | undefined>;
+  set(key: string, tokens: Tokens): Promise<void>;
+  delete(key: string): Promise<void>;
+}
+```
+
+### Built-in Implementations
+
+#### In-Memory Store
+
+Ephemeral storage for maximum security:
+
+```typescript
+const store = inMemoryStore();
+// Tokens exist only during process lifetime
+// Perfect for CLI tools that authenticate per-session
+```
+
+#### File Store
+
+Persistent storage for convenience:
+
+```typescript
+const store = fileStore("~/.myapp/tokens.json");
+// Tokens persist across sessions
+// Ideal for desktop apps with returning users
+```
+
+### Token Lifecycle
+
+```mermaid
+stateDiagram-v2
+    [*] --> NoToken: Initial State
+    NoToken --> Authorizing: User initiates OAuth
+    Authorizing --> HasToken: Successful auth
+    HasToken --> Refreshing: Token expired
+    Refreshing --> HasToken: Token refreshed
+    HasToken --> NoToken: User logs out
+    Refreshing --> Authorizing: Refresh failed
+```
+
+## MCP Integration Pattern
+
+The Model Context Protocol (MCP) integration showcases advanced OAuth patterns:
+
+### Dynamic Client Registration
+
+OAuth Callback supports [RFC 7591](https://www.rfc-editor.org/rfc/rfc7591.html) Dynamic Client Registration, allowing apps to register OAuth clients on-the-fly:
+
+```mermaid
+sequenceDiagram
+    participant App
+    participant OAuth Callback
+    participant Auth Server
+
+    App->>OAuth Callback: browserAuth() (no client_id)
+    OAuth Callback->>Auth Server: POST /register
+    Auth Server->>OAuth Callback: Return client_id, client_secret
+    OAuth Callback->>OAuth Callback: Store credentials
+    OAuth Callback->>Auth Server: Start normal OAuth flow
+```
+
+This eliminates the need for users to manually register OAuth applications.
+
+### The Provider Pattern
+
+The `browserAuth()` function returns an `OAuthClientProvider` that integrates with MCP SDK:
+
+```typescript
+interface OAuthClientProvider {
+  // Called by MCP SDK when authentication is needed
+  authenticate(params: AuthenticationParams): Promise<AuthenticationResult>;
+
+  // Manages token refresh automatically
+  refreshToken?(params: RefreshParams): Promise<RefreshResult>;
+}
+```
+
+## Request/Response Lifecycle
+
+Understanding the complete lifecycle helps when debugging OAuth flows:
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant App
+    participant OAuth Callback
+    participant Browser
+    participant Auth Server
+
+    User->>App: Run command
+    App->>OAuth Callback: getAuthCode(url)
+    OAuth Callback->>OAuth Callback: Start HTTP server
+    OAuth Callback->>Browser: Open auth URL
+    Browser->>Auth Server: GET /authorize
+    Auth Server->>Browser: Login page
+    Browser->>User: Show login
+    User->>Browser: Enter credentials
+    Browser->>Auth Server: POST credentials
+    Auth Server->>Browser: Consent page
+    User->>Browser: Approve access
+    Auth Server->>Browser: Redirect to localhost
+    Browser->>OAuth Callback: GET /callback?code=xyz
+    OAuth Callback->>Browser: Success HTML
+    OAuth Callback->>App: Return {code: "xyz"}
+    OAuth Callback->>OAuth Callback: Shutdown server
+    App->>Auth Server: Exchange code for token
+    Auth Server->>App: Return access token
+```
+
+## State Management
+
+OAuth Callback handles multiple types of state throughout the flow:
+
+### Server State
+
+The HTTP server maintains minimal state:
+
+- **Active**: Server is listening for callbacks
+- **Received**: Callback has been received
+- **Shutdown**: Server is closing
+
+### OAuth State
+
+The OAuth flow tracks:
+
+- **Authorization URL**: Where to send the user
+- **Expected state**: For CSRF validation
+- **Timeout timer**: For abandonment detection
+- **Abort signal**: For cancellation support
+
+### Token State
+
+When using token storage:
+
+- **No tokens**: Need to authenticate
+- **Valid tokens**: Can make API calls
+- **Expired tokens**: Need refresh
+- **Refresh failed**: Need re-authentication
+
+## Security Architecture
+
+Security is built into every layer of OAuth Callback:
+
+### Network Security
+
+```typescript
+// Localhost-only binding
+server.listen(port, "127.0.0.1");
+
+// IPv6 localhost support
+server.listen(port, "::1");
+
+// Reject non-localhost connections
+if (!isLocalhost(request.socket.remoteAddress)) {
+  return reject();
+}
+```
+
+### OAuth Security
+
+- **State parameter**: Prevents CSRF attacks
+- **PKCE support**: Protects authorization codes
+- **Timeout enforcement**: Limits exposure window
+- **Automatic cleanup**: Reduces attack surface
+
+### Token Security
+
+- **Memory storage option**: No persistence
+- **File permissions**: Restrictive when using file store
+- **No logging**: Tokens never logged or exposed
+- **Refresh handling**: Automatic token refresh
+
+## Template System
+
+OAuth Callback includes a simple but powerful template system for success/error pages:
+
+### Placeholder Substitution
+
+Templates support `{{placeholder}}` syntax:
+
+```html
+<h1>Error: {{error_description}}</h1>
+```
+
+Placeholders are automatically escaped to prevent XSS attacks.
+
+### Built-in Templates
+
+The library includes professional templates with:
+
+- Animated success checkmark
+- Clear error messages
+- Responsive design
+- Accessibility features
+
+### Custom Templates
+
+Applications can provide custom HTML:
+
+```typescript
+{
+  successHtml: "<h1>Welcome back!</h1>",
+  errorHtml: "<h1>Oops! {{error}}</h1>"
+}
+```
+
+## Cross-Runtime Compatibility
+
+OAuth Callback achieves cross-runtime compatibility through Web Standards APIs:
+
+### Universal APIs
+
+```typescript
+// Using Web Standards instead of Node.js-specific APIs
+new Request(); // Instead of http.IncomingMessage
+new Response(); // Instead of http.ServerResponse
+new URL(); // Instead of url.parse()
+new URLSearchParams(); // Instead of querystring
+```
+
+### Runtime Detection
+
+The library adapts to the runtime environment:
+
+```typescript
+// Node.js
+import { createServer } from "node:http";
+
+// Deno
+Deno.serve({ port: 3000 });
+
+// Bun
+Bun.serve({ port: 3000 });
+```
+
+## Performance Considerations
+
+OAuth Callback is designed for optimal performance:
+
+### Fast Startup
+
+- Minimal dependencies (only `open` package)
+- Lazy loading of heavy modules
+- Pre-compiled HTML templates
+
+### Efficient Memory Use
+
+- Server resources freed immediately after use
+- No persistent connections
+- Minimal state retention
+
+### Quick Response
+
+- Immediate browser redirect handling
+- Non-blocking I/O operations
+- Parallel browser launch and server start
+
+## Extension Points
+
+While OAuth Callback provides sensible defaults, it offers multiple extension points:
+
+### Custom Storage
+
+Implement the `TokenStore` interface for custom storage:
+
+```typescript
+class RedisStore implements TokenStore {
+  async get(key: string) {
+    /* Redis logic */
+  }
+  async set(key: string, tokens: Tokens) {
+    /* Redis logic */
+  }
+  async delete(key: string) {
+    /* Redis logic */
+  }
+}
+```
+
+### Request Interception
+
+Monitor or modify requests with callbacks:
+
+```typescript
+{
+  onRequest: (req) => {
+    console.log(`OAuth: ${req.method} ${req.url}`);
+    // Add telemetry, logging, etc.
+  };
+}
+```
+
+### Browser Control
+
+Customize browser launching:
+
+```typescript
+{
+  openBrowser: false,  // Manual browser opening
+  // Or provide custom launcher
+}
+```
+
+## Best Practices
+
+### Error Handling
+
+Always handle both OAuth errors and unexpected failures:
+
+```typescript
+try {
+  const result = await getAuthCode(authUrl);
+} catch (error) {
+  if (error instanceof OAuthError) {
+    // Handle OAuth-specific errors
+  } else {
+    // Handle unexpected errors
+  }
+}
+```
+
+### State Validation
+
+Always validate the state parameter:
+
+```typescript
+const state = crypto.randomUUID();
+// Include in auth URL
+const result = await getAuthCode(authUrl);
+if (result.state !== state) throw new Error("CSRF detected");
+```
+
+### Token Storage
+
+Choose storage based on security requirements:
+
+- **CLI tools**: Use `inMemoryStore()` for per-session auth
+- **Desktop apps**: Use `fileStore()` for user convenience
+- **Sensitive apps**: Always use in-memory storage
+
+### Timeout Configuration
+
+Set appropriate timeouts for your use case:
+
+- **Interactive apps**: 30-60 seconds
+- **Automated tools**: 5-10 seconds
+- **First-time setup**: 2-5 minutes

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -1,0 +1,1 @@
+# Examples

--- a/docs/examples/linear.md
+++ b/docs/examples/linear.md
@@ -1,0 +1,898 @@
+---
+title: Linear MCP Example
+description: Integrate with Linear's Model Context Protocol server using OAuth Callback for seamless issue tracking and project management automation.
+---
+
+# Linear MCP Example
+
+This example demonstrates how to integrate with Linear's Model Context Protocol (MCP) server using OAuth Callback's `browserAuth()` provider. Linear is a modern issue tracking and project management tool designed for high-performance teams. Through MCP integration, you can programmatically manage issues, projects, cycles, and more.
+
+## Overview
+
+The Linear MCP integration enables powerful project management automation:
+
+- **Issue Management** - Create, update, and track issues programmatically
+- **Project Tracking** - Monitor project progress and milestones
+- **Cycle Management** - Work with sprints and development cycles
+- **Team Collaboration** - Access team data and workflows
+- **Real-time Updates** - Subscribe to changes via MCP resources
+
+## Prerequisites
+
+Before starting with Linear MCP integration:
+
+- **Runtime Environment** - Bun, Node.js 18+, or Deno installed
+- **Linear Account** - Active Linear workspace with API access
+- **OAuth Application** - Linear OAuth app configured (or use DCR if supported)
+- **Port Availability** - Port 3000 (or custom) for OAuth callback
+- **Browser Access** - Default browser for authorization flow
+
+## Installation
+
+Install the required dependencies:
+
+::: code-group
+
+```bash [Bun]
+bun add oauth-callback @modelcontextprotocol/sdk
+```
+
+```bash [npm]
+npm install oauth-callback @modelcontextprotocol/sdk
+```
+
+```bash [pnpm]
+pnpm add oauth-callback @modelcontextprotocol/sdk
+```
+
+:::
+
+## Linear OAuth Setup
+
+### Creating a Linear OAuth Application
+
+1. Navigate to [Linear Settings > API](https://linear.app/settings/api)
+2. Click "Create new OAuth application"
+3. Configure your application:
+   - **Application name**: Your app name
+   - **Redirect URI**: `http://localhost:3000/callback`
+   - **Scopes**: Select required permissions (read, write, admin)
+4. Save your credentials:
+   - Client ID
+   - Client Secret
+
+### Required Scopes
+
+Select scopes based on your needs:
+
+| Scope             | Description                                |
+| ----------------- | ------------------------------------------ |
+| `read`            | Read access to issues, projects, and teams |
+| `write`           | Create and modify issues and comments      |
+| `admin`           | Manage team settings and workflows         |
+| `issues:create`   | Create new issues                          |
+| `issues:update`   | Update existing issues                     |
+| `comments:create` | Add comments to issues                     |
+
+## Basic Implementation
+
+### Simple Linear Connection
+
+Here's a basic example connecting to Linear's MCP server:
+
+```typescript
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { browserAuth, fileStore } from "oauth-callback/mcp";
+
+async function connectToLinear() {
+  console.log("🚀 Connecting to Linear MCP Server\n");
+
+  // Linear MCP endpoint (hypothetical - check Linear docs)
+  const serverUrl = new URL("https://mcp.linear.app");
+
+  // Create OAuth provider with credentials
+  const authProvider = browserAuth({
+    clientId: process.env.LINEAR_CLIENT_ID,
+    clientSecret: process.env.LINEAR_CLIENT_SECRET,
+    scope: "read write issues:create issues:update",
+    port: 3000,
+    store: fileStore("~/.mcp/linear-tokens.json"),
+    onRequest(req) {
+      console.log(`[OAuth] ${new URL(req.url).pathname}`);
+    },
+  });
+
+  try {
+    // Create MCP transport
+    const transport = new StreamableHTTPClientTransport(serverUrl, {
+      authProvider,
+    });
+
+    // Initialize MCP client
+    const client = new Client(
+      { name: "linear-automation", version: "1.0.0" },
+      { capabilities: {} },
+    );
+
+    // Connect to Linear
+    await client.connect(transport);
+    console.log("✅ Connected to Linear MCP!");
+
+    // List available capabilities
+    const tools = await client.listTools();
+    console.log("\n📝 Available tools:", tools);
+
+    await client.close();
+  } catch (error) {
+    console.error("❌ Connection failed:", error);
+  }
+}
+
+connectToLinear();
+```
+
+## OAuth Flow Details
+
+### Authorization Flow Diagram
+
+```mermaid
+sequenceDiagram
+    participant App as Your Application
+    participant OAuth as OAuth Callback
+    participant Browser
+    participant Linear as Linear OAuth
+    participant MCP as Linear MCP
+
+    App->>OAuth: Initialize browserAuth
+    App->>MCP: Connect to Linear MCP
+    MCP-->>App: 401 Unauthorized
+
+    Note over OAuth,Browser: OAuth Authorization
+    OAuth->>Browser: Open Linear OAuth URL
+    Browser->>Linear: Request authorization
+    Linear->>Browser: Show consent screen
+    Browser->>Linear: User approves
+    Linear->>Browser: Redirect to localhost:3000
+    Browser->>OAuth: GET /callback?code=xxx
+    OAuth->>App: Capture auth code
+
+    Note over App,Linear: Token Exchange
+    App->>Linear: POST /oauth/token
+    Linear-->>App: Access & refresh tokens
+    OAuth->>OAuth: Store tokens
+
+    App->>MCP: Reconnect with token
+    MCP-->>App: 200 OK + capabilities
+```
+
+### Configuration Options
+
+Configure the OAuth provider for Linear:
+
+```typescript
+const authProvider = browserAuth({
+  // OAuth credentials
+  clientId: process.env.LINEAR_CLIENT_ID,
+  clientSecret: process.env.LINEAR_CLIENT_SECRET,
+
+  // Required permissions
+  scope: "read write issues:create issues:update comments:create",
+
+  // Server configuration
+  port: 3000,
+  hostname: "localhost",
+  callbackPath: "/callback",
+
+  // Token storage
+  store: fileStore("~/.mcp/linear.json"),
+  storeKey: "linear-production",
+
+  // Timeouts
+  authTimeout: 300000, // 5 minutes
+
+  // Security
+  usePKCE: true, // Recommended for public clients
+
+  // Debugging
+  onRequest(req) {
+    const url = new URL(req.url);
+    console.log(`[${new Date().toISOString()}] ${req.method} ${url.pathname}`);
+  },
+});
+```
+
+## Working with Linear MCP
+
+### Issue Management
+
+Create and manage Linear issues through MCP:
+
+```typescript
+// Create a new issue
+const newIssue = await client.callTool("create_issue", {
+  title: "Fix authentication bug",
+  description: "Users unable to login with SSO",
+  teamId: "ENG",
+  priority: 1, // Urgent
+  labelIds: ["bug", "authentication"],
+  assigneeId: "user_123",
+});
+
+console.log("Created issue:", newIssue.identifier);
+
+// Update issue status
+await client.callTool("update_issue", {
+  issueId: newIssue.id,
+  stateId: "in_progress",
+});
+
+// Add a comment
+await client.callTool("add_comment", {
+  issueId: newIssue.id,
+  body: "Started investigation - found root cause in SSO handler",
+});
+
+// Search for issues
+const searchResults = await client.callTool("search_issues", {
+  query: "authentication bug",
+  teamId: "ENG",
+  state: ["todo", "in_progress"],
+  limit: 10,
+});
+```
+
+### Project Management
+
+Work with Linear projects and milestones:
+
+```typescript
+// Get project details
+const project = await client.callTool("get_project", {
+  projectId: "PROJ-123",
+});
+
+// Update project progress
+await client.callTool("update_project", {
+  projectId: "PROJ-123",
+  progress: 0.75, // 75% complete
+  status: "on_track",
+});
+
+// List project issues
+const projectIssues = await client.callTool("list_project_issues", {
+  projectId: "PROJ-123",
+  includeArchived: false,
+});
+
+// Create milestone
+const milestone = await client.callTool("create_milestone", {
+  name: "v2.0 Release",
+  targetDate: "2024-06-01",
+  projectId: "PROJ-123",
+});
+```
+
+### Cycle Management
+
+Manage development cycles (sprints):
+
+```typescript
+// Get current cycle
+const currentCycle = await client.callTool("get_current_cycle", {
+  teamId: "ENG",
+});
+
+// List cycle issues
+const cycleIssues = await client.callTool("list_cycle_issues", {
+  cycleId: currentCycle.id,
+});
+
+// Move issue to next cycle
+await client.callTool("update_issue", {
+  issueId: "ISS-456",
+  cycleId: currentCycle.nextCycle.id,
+});
+
+// Get cycle analytics
+const analytics = await client.callTool("get_cycle_analytics", {
+  cycleId: currentCycle.id,
+});
+
+console.log("Cycle completion:", analytics.completionRate);
+console.log("Issues completed:", analytics.completedCount);
+```
+
+### Resource Subscriptions
+
+Subscribe to Linear resources for real-time updates:
+
+```typescript
+// Subscribe to team updates
+await client.subscribeToResource({
+  uri: "linear://team/ENG",
+});
+
+// Subscribe to project changes
+await client.subscribeToResource({
+  uri: "linear://project/PROJ-123",
+});
+
+// Handle resource updates
+client.on("resource_updated", (resource) => {
+  console.log("Resource updated:", resource.uri);
+
+  if (resource.uri.startsWith("linear://issue/")) {
+    console.log("Issue changed:", resource.data);
+  }
+});
+```
+
+## Advanced Patterns
+
+### Custom Linear Client Class
+
+Create a reusable Linear MCP client:
+
+```typescript
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { browserAuth, fileStore } from "oauth-callback/mcp";
+
+class LinearMCPClient {
+  private client?: Client;
+  private authProvider: any;
+
+  constructor(options?: {
+    clientId?: string;
+    clientSecret?: string;
+    storePath?: string;
+  }) {
+    this.authProvider = browserAuth({
+      clientId: options?.clientId || process.env.LINEAR_CLIENT_ID,
+      clientSecret: options?.clientSecret || process.env.LINEAR_CLIENT_SECRET,
+      scope: "read write issues:create issues:update",
+      store: fileStore(options?.storePath || "~/.mcp/linear.json"),
+      port: 3000,
+      authTimeout: 300000,
+    });
+  }
+
+  async connect(): Promise<void> {
+    const serverUrl = new URL("https://mcp.linear.app");
+
+    const transport = new StreamableHTTPClientTransport(serverUrl, {
+      authProvider: this.authProvider,
+    });
+
+    this.client = new Client(
+      { name: "linear-client", version: "1.0.0" },
+      { capabilities: {} },
+    );
+
+    await this.client.connect(transport);
+    console.log("✅ Connected to Linear MCP");
+  }
+
+  async createIssue(params: {
+    title: string;
+    description?: string;
+    teamId: string;
+    priority?: number;
+    labels?: string[];
+  }): Promise<any> {
+    if (!this.client) throw new Error("Not connected");
+
+    return await this.client.callTool("create_issue", {
+      title: params.title,
+      description: params.description,
+      teamId: params.teamId,
+      priority: params.priority || 3,
+      labelIds: params.labels || [],
+    });
+  }
+
+  async searchIssues(query: string, teamId?: string): Promise<any> {
+    if (!this.client) throw new Error("Not connected");
+
+    return await this.client.callTool("search_issues", {
+      query,
+      teamId,
+      limit: 20,
+    });
+  }
+
+  async updateIssueStatus(issueId: string, status: string): Promise<void> {
+    if (!this.client) throw new Error("Not connected");
+
+    const states = {
+      todo: "state_todo_id",
+      in_progress: "state_in_progress_id",
+      done: "state_done_id",
+      cancelled: "state_cancelled_id",
+    };
+
+    await this.client.callTool("update_issue", {
+      issueId,
+      stateId: states[status] || status,
+    });
+  }
+
+  async addComment(issueId: string, comment: string): Promise<any> {
+    if (!this.client) throw new Error("Not connected");
+
+    return await this.client.callTool("add_comment", {
+      issueId,
+      body: comment,
+    });
+  }
+
+  async disconnect(): Promise<void> {
+    if (this.client) {
+      await this.client.close();
+      this.client = undefined;
+    }
+  }
+}
+
+// Usage
+const linear = new LinearMCPClient();
+await linear.connect();
+
+const issue = await linear.createIssue({
+  title: "Implement OAuth integration",
+  description: "Add OAuth support for third-party services",
+  teamId: "ENG",
+  priority: 2,
+  labels: ["feature", "authentication"],
+});
+
+await linear.updateIssueStatus(issue.id, "in_progress");
+await linear.addComment(issue.id, "Started implementation");
+await linear.disconnect();
+```
+
+### Automation Workflows
+
+Build powerful automations with Linear MCP:
+
+```typescript
+// Auto-triage incoming issues
+async function autoTriageIssues(client: Client) {
+  // Get untriaged issues
+  const untriaged = await client.callTool("search_issues", {
+    query: "no:assignee no:priority",
+    state: ["todo"],
+    limit: 50,
+  });
+
+  for (const issue of untriaged.issues) {
+    // Analyze issue content
+    const keywords =
+      issue.title.toLowerCase() + " " + issue.description.toLowerCase();
+
+    // Auto-assign based on keywords
+    let assignee = null;
+    let priority = 3; // Default: Medium
+
+    if (keywords.includes("crash") || keywords.includes("down")) {
+      priority = 1; // Urgent
+      assignee = "oncall_engineer";
+    } else if (
+      keywords.includes("security") ||
+      keywords.includes("vulnerability")
+    ) {
+      priority = 1;
+      assignee = "security_team";
+    } else if (keywords.includes("performance") || keywords.includes("slow")) {
+      priority = 2; // High
+      assignee = "performance_team";
+    }
+
+    // Update issue
+    await client.callTool("update_issue", {
+      issueId: issue.id,
+      priority,
+      assigneeId: assignee,
+      labelIds: ["auto-triaged"],
+    });
+
+    console.log(
+      `Triaged: ${issue.identifier} -> P${priority} ${assignee || "unassigned"}`,
+    );
+  }
+}
+
+// Sync Linear issues with external systems
+async function syncWithJira(client: Client, jiraClient: any) {
+  // Get recent Linear issues
+  const recentIssues = await client.callTool("search_issues", {
+    createdAfter: new Date(Date.now() - 86400000).toISOString(), // Last 24h
+    limit: 100,
+  });
+
+  for (const issue of recentIssues.issues) {
+    // Check if already synced
+    if (issue.metadata?.jiraKey) continue;
+
+    // Create in Jira
+    const jiraIssue = await jiraClient.createIssue({
+      summary: issue.title,
+      description: issue.description,
+      issueType: "Task",
+      project: "PROJ",
+    });
+
+    // Update Linear with Jira reference
+    await client.callTool("update_issue", {
+      issueId: issue.id,
+      metadata: {
+        jiraKey: jiraIssue.key,
+        syncedAt: new Date().toISOString(),
+      },
+    });
+
+    // Add sync comment
+    await client.callTool("add_comment", {
+      issueId: issue.id,
+      body: `🔄 Synced to Jira: [${jiraIssue.key}](https://jira.example.com/browse/${jiraIssue.key})`,
+    });
+  }
+}
+```
+
+### Batch Operations
+
+Efficiently handle multiple operations:
+
+```typescript
+class LinearBatchProcessor {
+  constructor(private client: Client) {}
+
+  async batchCreateIssues(
+    issues: Array<{
+      title: string;
+      description?: string;
+      teamId: string;
+    }>,
+  ): Promise<any[]> {
+    const results = [];
+
+    // Process in parallel with concurrency limit
+    const batchSize = 5;
+    for (let i = 0; i < issues.length; i += batchSize) {
+      const batch = issues.slice(i, i + batchSize);
+      const promises = batch.map((issue) =>
+        this.client.callTool("create_issue", issue),
+      );
+
+      const batchResults = await Promise.all(promises);
+      results.push(...batchResults);
+
+      console.log(
+        `Created batch ${i / batchSize + 1}: ${batchResults.length} issues`,
+      );
+    }
+
+    return results;
+  }
+
+  async bulkUpdatePriority(
+    issueIds: string[],
+    priority: number,
+  ): Promise<void> {
+    const promises = issueIds.map((id) =>
+      this.client.callTool("update_issue", {
+        issueId: id,
+        priority,
+      }),
+    );
+
+    await Promise.all(promises);
+    console.log(`Updated priority for ${issueIds.length} issues`);
+  }
+
+  async archiveCompletedIssues(
+    teamId: string,
+    olderThanDays = 30,
+  ): Promise<number> {
+    const cutoffDate = new Date();
+    cutoffDate.setDate(cutoffDate.getDate() - olderThanDays);
+
+    const completed = await this.client.callTool("search_issues", {
+      teamId,
+      state: ["done", "cancelled"],
+      completedBefore: cutoffDate.toISOString(),
+      limit: 100,
+    });
+
+    for (const issue of completed.issues) {
+      await this.client.callTool("archive_issue", {
+        issueId: issue.id,
+      });
+    }
+
+    return completed.issues.length;
+  }
+}
+```
+
+## Error Handling
+
+### Common Error Scenarios
+
+Handle Linear-specific errors gracefully:
+
+```typescript
+async function robustLinearOperation(
+  client: Client,
+  operation: () => Promise<any>,
+) {
+  const maxRetries = 3;
+  let lastError;
+
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    try {
+      return await operation();
+    } catch (error: any) {
+      lastError = error;
+
+      // Handle specific Linear errors
+      if (error.message.includes("RATE_LIMITED")) {
+        // Rate limit - exponential backoff
+        const delay = Math.pow(2, attempt) * 1000;
+        console.log(`Rate limited. Waiting ${delay}ms...`);
+        await new Promise((resolve) => setTimeout(resolve, delay));
+        continue;
+      }
+
+      if (error.message.includes("INVALID_TEAM_ID")) {
+        throw new Error(
+          "Invalid team ID. Check your Linear workspace settings.",
+        );
+      }
+
+      if (error.message.includes("INSUFFICIENT_PERMISSIONS")) {
+        throw new Error(
+          "Missing permissions. Request additional OAuth scopes.",
+        );
+      }
+
+      if (error.message.includes("RESOURCE_NOT_FOUND")) {
+        throw new Error("Linear resource not found. It may have been deleted.");
+      }
+
+      // Network errors - retry
+      if (
+        error.message.includes("ECONNRESET") ||
+        error.message.includes("ETIMEDOUT")
+      ) {
+        console.log(`Network error on attempt ${attempt}. Retrying...`);
+        continue;
+      }
+
+      // Unknown error - don't retry
+      throw error;
+    }
+  }
+
+  throw lastError;
+}
+
+// Usage
+const result = await robustLinearOperation(client, async () => {
+  return await client.callTool("create_issue", {
+    title: "New feature request",
+    teamId: "ENG",
+  });
+});
+```
+
+## Security Best Practices
+
+### Token Management
+
+Secure your Linear OAuth tokens:
+
+```typescript
+import { browserAuth, fileStore } from "oauth-callback/mcp";
+import { createCipheriv, createDecipheriv, randomBytes, scrypt } from "crypto";
+import { promisify } from "util";
+
+// Encrypted token storage
+class EncryptedLinearStore {
+  private key: Buffer;
+  private store = fileStore("~/.mcp/linear-encrypted.json");
+
+  async init(password: string) {
+    const salt = randomBytes(16);
+    this.key = (await promisify(scrypt)(password, salt, 32)) as Buffer;
+  }
+
+  async get(key: string): Promise<any> {
+    const encrypted = await this.store.get(key);
+    if (!encrypted) return null;
+
+    // Decrypt tokens
+    return this.decrypt(encrypted);
+  }
+
+  async set(key: string, tokens: any): Promise<void> {
+    // Encrypt before storing
+    const encrypted = this.encrypt(tokens);
+    await this.store.set(key, encrypted);
+  }
+
+  private encrypt(data: any): string {
+    const iv = randomBytes(16);
+    const cipher = createCipheriv("aes-256-gcm", this.key, iv);
+    // ... encryption logic
+    return encrypted;
+  }
+
+  private decrypt(encrypted: string): any {
+    // ... decryption logic
+    return decrypted;
+  }
+}
+```
+
+### Environment Configuration
+
+Use environment variables for sensitive data:
+
+```bash
+# .env file (never commit!)
+LINEAR_CLIENT_ID=lin_oauth_client_xxx
+LINEAR_CLIENT_SECRET=lin_oauth_secret_xxx
+LINEAR_WORKSPACE_ID=workspace_123
+LINEAR_TEAM_ID=team_eng
+```
+
+```typescript
+// Load configuration
+import { config } from "dotenv";
+config();
+
+const authProvider = browserAuth({
+  clientId: process.env.LINEAR_CLIENT_ID!,
+  clientSecret: process.env.LINEAR_CLIENT_SECRET!,
+  scope: "read write",
+  store: fileStore(),
+});
+```
+
+## Testing
+
+### Mock Linear MCP Server
+
+Test your integration without hitting Linear's API:
+
+```typescript
+import { createServer } from "http";
+
+class MockLinearMCPServer {
+  private server: any;
+  private issues = new Map();
+
+  async start(port = 4000) {
+    this.server = createServer((req, res) => {
+      // Mock MCP endpoints
+      if (req.url === "/capabilities") {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(
+          JSON.stringify({
+            tools: [
+              { name: "create_issue", description: "Create issue" },
+              { name: "update_issue", description: "Update issue" },
+              { name: "search_issues", description: "Search issues" },
+            ],
+          }),
+        );
+      }
+      // ... other endpoints
+    });
+
+    await new Promise((resolve) => {
+      this.server.listen(port, resolve);
+    });
+  }
+
+  async stop() {
+    await new Promise((resolve) => this.server.close(resolve));
+  }
+}
+
+// Test usage
+describe("Linear MCP Integration", () => {
+  let mockServer: MockLinearMCPServer;
+
+  beforeAll(async () => {
+    mockServer = new MockLinearMCPServer();
+    await mockServer.start();
+  });
+
+  afterAll(async () => {
+    await mockServer.stop();
+  });
+
+  it("should create an issue", async () => {
+    // Test implementation
+  });
+});
+```
+
+## Troubleshooting
+
+### Common Issues
+
+::: details OAuth authorization fails
+
+Check your Linear OAuth app configuration:
+
+```typescript
+// Verify redirect URI matches
+const authProvider = browserAuth({
+  clientId: "...",
+  clientSecret: "...",
+  port: 3000, // Must match redirect URI port
+  callbackPath: "/callback", // Must match redirect URI path
+});
+```
+
+:::
+
+::: details Rate limiting errors
+
+Implement rate limit handling:
+
+```typescript
+class RateLimitedClient {
+  private requestCount = 0;
+  private resetTime = Date.now() + 60000;
+
+  async callTool(name: string, params: any) {
+    // Check rate limit
+    if (Date.now() > this.resetTime) {
+      this.requestCount = 0;
+      this.resetTime = Date.now() + 60000;
+    }
+
+    if (this.requestCount >= 100) {
+      const waitTime = this.resetTime - Date.now();
+      await new Promise((resolve) => setTimeout(resolve, waitTime));
+      this.requestCount = 0;
+    }
+
+    this.requestCount++;
+    return await this.client.callTool(name, params);
+  }
+}
+```
+
+:::
+
+::: details Token refresh fails
+
+Handle token refresh errors:
+
+```typescript
+const authProvider = browserAuth({
+  store: fileStore(),
+  onTokenRefreshError: async (error) => {
+    console.error("Token refresh failed:", error);
+    // Clear invalid tokens
+    await authProvider.invalidateCredentials("tokens");
+    // Trigger re-authentication
+    throw new Error("Re-authentication required");
+  },
+});
+```
+
+:::
+
+## Related Resources
+
+- [Linear API Documentation](https://developers.linear.app/docs/graphql/working-with-the-graphql-api) - Official Linear API reference
+- [browserAuth API](/api/browser-auth) - OAuth provider documentation
+- [MCP SDK Documentation](https://modelcontextprotocol.io/docs) - Model Context Protocol reference

--- a/docs/examples/notion.md
+++ b/docs/examples/notion.md
@@ -1,0 +1,568 @@
+---
+title: Notion MCP Example
+description: Connect to Notion's Model Context Protocol server using OAuth Callback with Dynamic Client Registration - no pre-configured OAuth app required.
+---
+
+# Notion MCP Example
+
+This example demonstrates how to connect to Notion's Model Context Protocol (MCP) server using OAuth Callback's `browserAuth()` provider with Dynamic Client Registration (DCR). Unlike traditional OAuth flows that require pre-registering an OAuth application, this example shows how to automatically register and authenticate with Notion's authorization server.
+
+## Overview
+
+The Notion MCP integration showcases several advanced features:
+
+- **Dynamic Client Registration (RFC 7591)** - Automatic OAuth client registration
+- **Model Context Protocol Integration** - Seamless MCP SDK authentication
+- **Browser-Based Authorization** - Automatic browser opening for user consent
+- **Token Management** - Automatic token storage and retrieval
+- **Zero Configuration** - No client ID or secret required
+
+## Prerequisites
+
+Before running this example, ensure you have:
+
+- **Bun, Node.js 18+, or Deno** installed
+- **Port 3000** available for the OAuth callback server
+- **Default browser** configured for opening authorization URLs
+- **Internet connection** to reach Notion's servers
+
+## Installation
+
+Install the required dependencies:
+
+::: code-group
+
+```bash [Bun]
+bun add oauth-callback @modelcontextprotocol/sdk
+```
+
+```bash [npm]
+npm install oauth-callback @modelcontextprotocol/sdk
+```
+
+```bash [pnpm]
+pnpm add oauth-callback @modelcontextprotocol/sdk
+```
+
+:::
+
+## Quick Start
+
+### Running the Example
+
+The simplest way to run the Notion MCP example:
+
+```bash
+# Clone the repository
+git clone https://github.com/kriasoft/oauth-callback.git
+cd oauth-callback
+
+# Install dependencies
+bun install
+
+# Run the Notion example
+bun run example:notion
+```
+
+The example will:
+
+1. Start a local OAuth callback server on port 3000
+2. Open your browser to Notion's authorization page
+3. Capture the authorization code after you approve
+4. Exchange the code for access tokens
+5. Connect to Notion's MCP server
+6. Display available tools and resources
+
+## Complete Example Code
+
+Here's the full implementation demonstrating Notion MCP integration:
+
+```typescript
+#!/usr/bin/env bun
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { browserAuth, inMemoryStore } from "oauth-callback/mcp";
+
+async function connectToNotion() {
+  console.log("🚀 Starting OAuth flow with Notion MCP Server\n");
+
+  const serverUrl = new URL("https://mcp.notion.com/mcp");
+
+  // Create OAuth provider - no client_id or client_secret needed!
+  const authProvider = browserAuth({
+    port: 3000,
+    scope: "read write",
+    store: inMemoryStore(), // Use fileStore() for persistence
+    onRequest(req) {
+      const url = new URL(req.url);
+      console.log(`📨 OAuth: ${req.method} ${url.pathname}`);
+    },
+  });
+
+  try {
+    // Create MCP transport with OAuth provider
+    const transport = new StreamableHTTPClientTransport(serverUrl, {
+      authProvider,
+    });
+
+    // Create MCP client
+    const client = new Client(
+      { name: "notion-example", version: "1.0.0" },
+      { capabilities: {} },
+    );
+
+    // Connect triggers OAuth flow if needed
+    await client.connect(transport);
+    console.log("✅ Connected to Notion MCP server!");
+
+    // List available tools
+    const tools = await client.listTools();
+    console.log("\n📝 Available tools:");
+    for (const tool of tools.tools || []) {
+      console.log(`   - ${tool.name}: ${tool.description}`);
+    }
+
+    // List available resources
+    const resources = await client.listResources();
+    console.log("\n📂 Available resources:");
+    for (const resource of resources.resources || []) {
+      console.log(`   - ${resource.uri}: ${resource.name}`);
+    }
+
+    await client.close();
+  } catch (error) {
+    console.error("❌ Connection failed:", error);
+  }
+}
+
+connectToNotion();
+```
+
+## How It Works
+
+### OAuth Flow Sequence
+
+```mermaid
+sequenceDiagram
+    participant App as Your App
+    participant OAuth as OAuth Callback
+    participant Browser
+    participant Notion as Notion Auth
+    participant MCP as Notion MCP
+
+    App->>OAuth: Create browserAuth provider
+    App->>MCP: Connect via transport
+    MCP-->>App: 401 Unauthorized
+
+    Note over App,OAuth: Dynamic Client Registration
+    App->>Notion: POST /oauth/register
+    Notion-->>App: client_id, client_secret
+    OAuth->>OAuth: Store credentials
+
+    Note over OAuth,Browser: Authorization Flow
+    OAuth->>Browser: Open authorization URL
+    Browser->>Notion: User authorizes
+    Notion->>Browser: Redirect to localhost:3000
+    Browser->>OAuth: GET /callback?code=xxx
+    OAuth->>App: Return auth code
+
+    Note over App,MCP: Token Exchange
+    App->>Notion: POST /oauth/token
+    Notion-->>App: access_token, refresh_token
+    OAuth->>OAuth: Store tokens
+
+    App->>MCP: Connect with token
+    MCP-->>App: 200 OK + capabilities
+```
+
+### Dynamic Client Registration
+
+Unlike traditional OAuth, Notion's MCP server supports Dynamic Client Registration (RFC 7591):
+
+1. **No Pre-Registration** - You don't need to manually register an OAuth app
+2. **Automatic Registration** - The client registers itself on first use
+3. **Credential Persistence** - Client credentials are stored for reuse
+4. **Simplified Distribution** - Ship apps without OAuth setup instructions
+
+## Key Features
+
+### Browser-Based Authorization
+
+The `browserAuth()` provider handles the complete OAuth flow:
+
+```typescript
+const authProvider = browserAuth({
+  port: 3000, // Callback server port
+  scope: "read write", // Requested permissions
+  store: inMemoryStore(), // Token storage
+  onRequest(req) {
+    // Request logging
+    console.log(`OAuth: ${req.url}`);
+  },
+});
+```
+
+### Token Storage Options
+
+Choose between ephemeral and persistent storage:
+
+::: code-group
+
+```typescript [Ephemeral Storage]
+// Tokens lost on restart (more secure)
+const authProvider = browserAuth({
+  store: inMemoryStore(),
+});
+```
+
+```typescript [Persistent Storage]
+// Tokens saved to disk (convenient)
+import { fileStore } from "oauth-callback/mcp";
+
+const authProvider = browserAuth({
+  store: fileStore(), // Default: ~/.mcp/tokens.json
+});
+```
+
+```typescript [Custom Location]
+// Specify custom file path
+const authProvider = browserAuth({
+  store: fileStore("~/my-app/notion-tokens.json"),
+});
+```
+
+:::
+
+### Error Handling
+
+Properly handle authentication failures:
+
+```typescript
+try {
+  await client.connect(transport);
+} catch (error) {
+  if (error.message.includes("Unauthorized")) {
+    console.log("Authorization required - check browser");
+  } else if (error.message.includes("access_denied")) {
+    console.log("User cancelled authorization");
+  } else {
+    console.error("Connection failed:", error);
+  }
+}
+```
+
+## Working with Notion MCP
+
+### Available Tools
+
+Once connected, you can use Notion's MCP tools:
+
+```typescript
+// Search for content
+const searchResults = await client.callTool("search_objects", {
+  query: "meeting notes",
+  limit: 10,
+});
+
+// Create a new page
+const newPage = await client.callTool("create_page", {
+  title: "My New Page",
+  content: "Page content here",
+});
+
+// Update existing content
+const updated = await client.callTool("update_page", {
+  page_id: "page-123",
+  content: "Updated content",
+});
+```
+
+### Available Resources
+
+Access Notion resources through MCP:
+
+```typescript
+// List all resources
+const resources = await client.listResources();
+
+// Read a specific resource
+const pageContent = await client.readResource({
+  uri: "notion://page/page-123",
+});
+
+// Subscribe to changes
+await client.subscribeToResource({
+  uri: "notion://database/db-456",
+});
+```
+
+## Advanced Configuration
+
+### Custom Success Pages
+
+Provide branded callback pages:
+
+```typescript
+const authProvider = browserAuth({
+  successHtml: `
+    <!DOCTYPE html>
+    <html>
+      <head>
+        <title>Notion Connected!</title>
+        <style>
+          body {
+            font-family: -apple-system, system-ui, sans-serif;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            height: 100vh;
+            background: linear-gradient(135deg, #000000 0%, #434343 100%);
+            color: white;
+          }
+        </style>
+      </head>
+      <body>
+        <div>
+          <h1>✨ Connected to Notion!</h1>
+          <p>You can close this window and return to your app.</p>
+        </div>
+      </body>
+    </html>
+  `,
+});
+```
+
+### Request Logging
+
+Debug OAuth flow with detailed logging:
+
+```typescript
+const authProvider = browserAuth({
+  onRequest(req) {
+    const url = new URL(req.url);
+    const timestamp = new Date().toISOString();
+
+    console.log(`[${timestamp}] OAuth Request`);
+    console.log(`  Method: ${req.method}`);
+    console.log(`  Path: ${url.pathname}`);
+
+    if (url.pathname === "/callback") {
+      console.log(`  Code: ${url.searchParams.get("code")}`);
+      console.log(`  State: ${url.searchParams.get("state")}`);
+    }
+  },
+});
+```
+
+### Multi-Account Support
+
+Support multiple Notion accounts:
+
+```typescript
+function createNotionAuth(accountName: string) {
+  return browserAuth({
+    store: fileStore(`~/.mcp/notion-${accountName}.json`),
+    storeKey: `notion-${accountName}`,
+    port: 3000 + Math.floor(Math.random() * 1000), // Random port
+  });
+}
+
+// Use different accounts
+const personalAuth = createNotionAuth("personal");
+const workAuth = createNotionAuth("work");
+```
+
+## Troubleshooting
+
+### Common Issues and Solutions
+
+::: details Browser doesn't open automatically
+
+If the browser doesn't open automatically:
+
+```typescript
+const authProvider = browserAuth({
+  openBrowser: false, // Disable auto-open
+});
+
+// Manually instruct user
+console.log("Please open this URL in your browser:");
+console.log(authorizationUrl);
+```
+
+:::
+
+::: details Port 3000 is already in use
+
+Use a different port for the callback server:
+
+```typescript
+const authProvider = browserAuth({
+  port: 8080, // Use alternative port
+});
+```
+
+:::
+
+::: details Tokens not persisting
+
+Ensure you're using file storage, not in-memory:
+
+```typescript
+import { fileStore } from "oauth-callback/mcp";
+
+const authProvider = browserAuth({
+  store: fileStore(), // ✅ Persistent storage
+  // store: inMemoryStore() // ❌ Lost on restart
+});
+```
+
+:::
+
+::: details Authorization fails repeatedly
+
+Clear stored credentials and try again:
+
+```typescript
+// Clear all stored data
+await authProvider.invalidateCredentials("all");
+
+// Or clear specific data
+await authProvider.invalidateCredentials("tokens");
+await authProvider.invalidateCredentials("client");
+```
+
+:::
+
+## Security Considerations
+
+### Best Practices
+
+1. **Use Ephemeral Storage for Sensitive Data**
+
+   ```typescript
+   // Tokens are never written to disk
+   const authProvider = browserAuth({
+     store: inMemoryStore(),
+   });
+   ```
+
+2. **Validate State Parameter**
+   - The library automatically generates and validates state parameters
+   - Prevents CSRF attacks during authorization
+
+3. **PKCE Protection**
+   - Enabled by default for enhanced security
+   - Prevents authorization code interception
+
+4. **Secure File Permissions**
+   - File storage uses mode 0600 (owner read/write only)
+   - Tokens are protected from other users on the system
+
+### Token Security
+
+::: warning
+Never commit tokens to version control:
+
+```bash
+# Add to .gitignore
+~/.mcp/
+*.json
+tokens.json
+```
+
+:::
+
+## Complete Working Example
+
+For a production-ready implementation with full error handling:
+
+```typescript
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { browserAuth, fileStore } from "oauth-callback/mcp";
+
+class NotionMCPClient {
+  private client?: Client;
+  private authProvider: any;
+
+  constructor() {
+    this.authProvider = browserAuth({
+      port: 3000,
+      scope: "read write",
+      store: fileStore("~/.mcp/notion.json"),
+      authTimeout: 300000, // 5 minutes
+      onRequest: this.logRequest.bind(this),
+    });
+  }
+
+  private logRequest(req: Request) {
+    const url = new URL(req.url);
+    console.log(`[OAuth] ${req.method} ${url.pathname}`);
+  }
+
+  async connect(): Promise<void> {
+    const serverUrl = new URL("https://mcp.notion.com/mcp");
+
+    const transport = new StreamableHTTPClientTransport(serverUrl, {
+      authProvider: this.authProvider,
+    });
+
+    this.client = new Client(
+      { name: "notion-client", version: "1.0.0" },
+      { capabilities: {} },
+    );
+
+    try {
+      await this.client.connect(transport);
+      console.log("✅ Connected to Notion MCP");
+    } catch (error: any) {
+      if (error.message.includes("Unauthorized")) {
+        throw new Error("Authorization required. Please check your browser.");
+      }
+      throw error;
+    }
+  }
+
+  async search(query: string): Promise<any> {
+    if (!this.client) throw new Error("Not connected");
+
+    return await this.client.callTool("search_objects", {
+      query,
+      limit: 10,
+    });
+  }
+
+  async disconnect(): Promise<void> {
+    if (this.client) {
+      await this.client.close();
+      this.client = undefined;
+    }
+  }
+}
+
+// Usage
+async function main() {
+  const notion = new NotionMCPClient();
+
+  try {
+    await notion.connect();
+
+    const results = await notion.search("project roadmap");
+    console.log("Search results:", results);
+
+    await notion.disconnect();
+  } catch (error) {
+    console.error("Error:", error);
+  }
+}
+
+main();
+```
+
+## Related Resources
+
+- [browserAuth API Documentation](/api/browser-auth) - Complete API reference
+- [Storage Providers](/api/storage-providers) - Token storage options
+- [Core Concepts](/core-concepts) - OAuth and MCP architecture
+- [GitHub Example](https://github.com/kriasoft/oauth-callback/blob/main/examples/notion.ts) - Source code

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,555 @@
+---
+title: Getting Started
+description: Quick start guide to implement OAuth 2.0 authorization code flow in your CLI tools, desktop apps, and MCP clients using oauth-callback.
+---
+
+# Getting Started {#top}
+
+This guide will walk you through adding OAuth authentication to your application in just a few minutes. Whether you're building a CLI tool, desktop app, or MCP client, **OAuth Callback** handles the complexity of receiving authorization codes via localhost callbacks.
+
+## Prerequisites
+
+Before you begin, ensure you have:
+
+- **Runtime**: Node.js 18+, Deno, or Bun installed
+- **OAuth App**: Registered with your OAuth provider (unless using Dynamic Client Registration)
+- **Redirect URI**: Set to `http://localhost:3000/callback` in your OAuth app settings
+
+## Installation
+
+Install the package using your preferred package manager:
+
+::: code-group
+
+```bash [Bun]
+bun add oauth-callback
+```
+
+```bash [npm]
+npm install oauth-callback
+```
+
+```bash [pnpm]
+pnpm add oauth-callback
+```
+
+```bash [Yarn]
+yarn add oauth-callback
+```
+
+:::
+
+## Basic Usage
+
+The simplest way to capture an OAuth authorization code is with the `getAuthCode()` function:
+
+```typescript
+import { getAuthCode } from "oauth-callback";
+
+// Construct your OAuth authorization URL
+const authUrl =
+  "https://github.com/login/oauth/authorize?" +
+  new URLSearchParams({
+    client_id: "your_client_id",
+    redirect_uri: "http://localhost:3000/callback",
+    scope: "user:email",
+    state: crypto.randomUUID(), // For CSRF protection
+  });
+
+// Get the authorization code
+const result = await getAuthCode(authUrl);
+
+console.log("Authorization code:", result.code);
+console.log("State:", result.state);
+```
+
+That's it! The library will:
+
+1. Start a local HTTP server on port 3000
+2. Open the user's browser to the authorization URL
+3. Capture the callback with the authorization code
+4. Return the code and automatically shut down the server
+
+## Step-by-Step Implementation
+
+Let's build a complete OAuth flow for a CLI application:
+
+### Step 1: Register Your OAuth Application
+
+First, register your application with your OAuth provider:
+
+::: details GitHub OAuth Setup
+
+1. Go to **Settings** → **Developer settings** → **OAuth Apps**
+2. Click **New OAuth App**
+3. Fill in:
+   - **Application name**: Your app name
+   - **Homepage URL**: Your website or GitHub repo
+   - **Authorization callback URL**: `http://localhost:3000/callback`
+4. Save and copy your **Client ID** and **Client Secret**
+   :::
+
+::: details Google OAuth Setup
+
+1. Go to [Google Cloud Console](https://console.cloud.google.com/)
+2. Create or select a project
+3. Enable the necessary APIs
+4. Go to **APIs & Services** → **Credentials**
+5. Click **Create Credentials** → **OAuth client ID**
+6. Choose **Desktop app** as application type
+7. Add `http://localhost:3000/callback` to authorized redirect URIs
+8. Copy your **Client ID** and **Client Secret**
+   :::
+
+### Step 2: Implement the Authorization Flow
+
+Create a file `auth.ts` with your OAuth implementation:
+
+```typescript
+import { getAuthCode, OAuthError } from "oauth-callback";
+
+async function authenticate() {
+  // Generate state for CSRF protection
+  const state = crypto.randomUUID();
+
+  // Build authorization URL
+  const authUrl = new URL("https://github.com/login/oauth/authorize");
+  authUrl.searchParams.set("client_id", process.env.GITHUB_CLIENT_ID!);
+  authUrl.searchParams.set("redirect_uri", "http://localhost:3000/callback");
+  authUrl.searchParams.set("scope", "user:email");
+  authUrl.searchParams.set("state", state);
+
+  try {
+    // Get authorization code
+    console.log("Opening browser for authentication...");
+    const result = await getAuthCode(authUrl.toString());
+
+    // Validate state
+    if (result.state !== state) {
+      throw new Error("State mismatch - possible CSRF attack");
+    }
+
+    console.log("✅ Authorization successful!");
+    return result.code;
+  } catch (error) {
+    if (error instanceof OAuthError) {
+      console.error("❌ OAuth error:", error.error_description || error.error);
+    } else {
+      console.error("❌ Unexpected error:", error);
+    }
+    throw error;
+  }
+}
+```
+
+### Step 3: Exchange Code for Access Token
+
+After getting the authorization code, exchange it for an access token:
+
+```typescript
+async function exchangeCodeForToken(code: string) {
+  const response = await fetch("https://github.com/login/oauth/access_token", {
+    method: "POST",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      client_id: process.env.GITHUB_CLIENT_ID,
+      client_secret: process.env.GITHUB_CLIENT_SECRET,
+      code: code,
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Token exchange failed: ${response.statusText}`);
+  }
+
+  const data = await response.json();
+
+  if (data.error) {
+    throw new Error(`OAuth error: ${data.error_description || data.error}`);
+  }
+
+  return data.access_token;
+}
+```
+
+### Step 4: Use the Access Token
+
+Now you can use the access token to make authenticated API requests:
+
+```typescript
+async function getUserInfo(accessToken: string) {
+  const response = await fetch("https://api.github.com/user", {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      Accept: "application/vnd.github.v3+json",
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`API request failed: ${response.statusText}`);
+  }
+
+  return response.json();
+}
+
+// Complete flow
+async function main() {
+  const code = await authenticate();
+  const token = await exchangeCodeForToken(code);
+  const user = await getUserInfo(token);
+
+  console.log(`Hello, ${user.name}! 👋`);
+  console.log(`Email: ${user.email}`);
+}
+
+main().catch(console.error);
+```
+
+## MCP SDK Integration
+
+For Model Context Protocol applications, use the `browserAuth()` provider for seamless integration:
+
+### Quick Setup
+
+```typescript
+import { browserAuth, inMemoryStore } from "oauth-callback/mcp";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+
+// Create OAuth provider for MCP
+const authProvider = browserAuth({
+  store: inMemoryStore(), // Or fileStore() for persistence
+  scope: "read write",
+});
+
+// Connect to MCP server with OAuth
+const transport = new StreamableHTTPClientTransport(
+  new URL("https://mcp.notion.com/mcp"),
+  { authProvider },
+);
+
+const client = new Client(
+  { name: "my-app", version: "1.0.0" },
+  { capabilities: {} },
+);
+
+await client.connect(transport);
+```
+
+### Token Storage Options
+
+Choose between ephemeral and persistent token storage:
+
+::: code-group
+
+```typescript [Ephemeral (Memory)]
+import { browserAuth, inMemoryStore } from "oauth-callback/mcp";
+
+// Tokens are lost when the process exits
+const authProvider = browserAuth({
+  store: inMemoryStore(),
+});
+```
+
+```typescript [Persistent (File)]
+import { browserAuth, fileStore } from "oauth-callback/mcp";
+
+// Tokens persist across sessions
+const authProvider = browserAuth({
+  store: fileStore(), // Saves to ~/.mcp/tokens.json
+});
+
+// Or specify custom location
+const customAuth = browserAuth({
+  store: fileStore("/path/to/tokens.json"),
+});
+```
+
+:::
+
+### Pre-configured Credentials
+
+If you have pre-registered OAuth credentials:
+
+```typescript
+const authProvider = browserAuth({
+  clientId: "your-client-id",
+  clientSecret: "your-client-secret",
+  scope: "read write",
+  store: fileStore(),
+  storeKey: "my-app", // Namespace for multiple apps
+});
+```
+
+## Advanced Configuration
+
+### Custom Port and Timeout
+
+Configure the callback server port and timeout:
+
+```typescript
+const result = await getAuthCode({
+  authorizationUrl: authUrl,
+  port: 8080, // Use port 8080 instead of 3000
+  timeout: 60000, // 60 second timeout (default: 30s)
+  hostname: "127.0.0.1", // Bind to specific IP
+});
+```
+
+### Custom HTML Templates
+
+Customize the success and error pages shown to users:
+
+```typescript
+const result = await getAuthCode({
+  authorizationUrl: authUrl,
+  successHtml: `
+    <html>
+      <body style="font-family: system-ui; text-align: center; padding: 50px;">
+        <h1>✅ Authorization Successful!</h1>
+        <p>You can now close this window and return to the application.</p>
+      </body>
+    </html>
+  `,
+  errorHtml: `
+    <html>
+      <body style="font-family: system-ui; text-align: center; padding: 50px;">
+        <h1>❌ Authorization Failed</h1>
+        <p>Error: {{error_description}}</p>
+        <p>Please try again or contact support.</p>
+      </body>
+    </html>
+  `,
+});
+```
+
+### Request Logging
+
+Add logging for debugging OAuth flows:
+
+```typescript
+const result = await getAuthCode({
+  authorizationUrl: authUrl,
+  onRequest: (req) => {
+    console.log(`[OAuth] ${req.method} ${req.url}`);
+    console.log("[OAuth] Headers:", Object.fromEntries(req.headers));
+  },
+});
+```
+
+### Programmatic Cancellation
+
+Support user cancellation with AbortSignal:
+
+```typescript
+const controller = new AbortController();
+
+// Cancel after 10 seconds
+setTimeout(() => controller.abort(), 10000);
+
+// Or cancel on user input
+process.on("SIGINT", () => {
+  console.log("\nCancelling OAuth flow...");
+  controller.abort();
+});
+
+try {
+  const result = await getAuthCode({
+    authorizationUrl: authUrl,
+    signal: controller.signal,
+  });
+} catch (error) {
+  if (error.message === "Operation aborted") {
+    console.log("OAuth flow was cancelled");
+  }
+}
+```
+
+## Error Handling
+
+Proper error handling ensures a good user experience:
+
+```typescript
+import { getAuthCode, OAuthError } from "oauth-callback";
+
+try {
+  const result = await getAuthCode(authUrl);
+  // Success path
+} catch (error) {
+  if (error instanceof OAuthError) {
+    // OAuth-specific errors from the provider
+    switch (error.error) {
+      case "access_denied":
+        console.error("User denied access");
+        break;
+      case "invalid_scope":
+        console.error("Invalid scope requested");
+        break;
+      case "server_error":
+        console.error("Authorization server error");
+        break;
+      default:
+        console.error(`OAuth error: ${error.error_description || error.error}`);
+    }
+  } else if (error.message === "Timeout waiting for callback") {
+    console.error("Authorization timed out - please try again");
+  } else if (error.message === "Operation aborted") {
+    console.error("Authorization was cancelled");
+  } else {
+    console.error("Unexpected error:", error);
+  }
+}
+```
+
+## Security Best Practices
+
+### Always Use State Parameter
+
+Protect against CSRF attacks with a state parameter:
+
+```typescript
+const state = crypto.randomUUID();
+
+const authUrl = `https://example.com/authorize?state=${state}&...`;
+const result = await getAuthCode(authUrl);
+
+if (result.state !== state) {
+  throw new Error("State mismatch - possible CSRF attack");
+}
+```
+
+### Implement PKCE for Public Clients
+
+For enhanced security, implement Proof Key for Code Exchange:
+
+```typescript
+import { createHash, randomBytes } from "node:crypto";
+
+// Generate PKCE challenge
+const verifier = randomBytes(32).toString("base64url");
+const challenge = createHash("sha256").update(verifier).digest("base64url");
+
+// Include in authorization request
+const authUrl = new URL("https://example.com/authorize");
+authUrl.searchParams.set("code_challenge", challenge);
+authUrl.searchParams.set("code_challenge_method", "S256");
+// ... other parameters
+
+const result = await getAuthCode(authUrl.toString());
+
+// Include verifier in token exchange
+const tokenResponse = await fetch(tokenUrl, {
+  method: "POST",
+  body: new URLSearchParams({
+    code: result.code,
+    code_verifier: verifier,
+    // ... other parameters
+  }),
+});
+```
+
+### Secure Token Storage
+
+Choose appropriate token storage based on your security requirements:
+
+- **Use `inMemoryStore()`** for maximum security (tokens lost on restart)
+- **Use `fileStore()`** only when persistence is required
+- **Never commit tokens** to version control
+- **Consider encryption** for file-based storage in production
+
+## Testing Your Implementation
+
+### Local Testing with Demo
+
+Test the library without real OAuth credentials:
+
+```bash
+# Run interactive demo
+bun run example:demo
+
+# The demo includes a mock OAuth server for testing
+```
+
+### Testing with Real Providers
+
+::: code-group
+
+```bash [GitHub]
+# Set credentials in .env file
+GITHUB_CLIENT_ID=your_client_id
+GITHUB_CLIENT_SECRET=your_client_secret
+
+# Run example
+bun run example:github
+```
+
+```bash [Notion MCP]
+# No credentials needed - uses Dynamic Client Registration
+bun run example:notion
+```
+
+:::
+
+## Troubleshooting
+
+### Common Issues and Solutions
+
+::: details Port Already in Use
+If port 3000 is already in use:
+
+```typescript
+const result = await getAuthCode({
+  authorizationUrl: authUrl,
+  port: 8080, // Use a different port
+});
+```
+
+Also update your OAuth app's redirect URI to match.
+:::
+
+::: details Browser Doesn't Open
+If the browser doesn't open automatically:
+
+```typescript
+const result = await getAuthCode({
+  authorizationUrl: authUrl,
+  openBrowser: false, // Disable auto-open
+});
+
+console.log(`Please open: ${authUrl}`);
+```
+
+:::
+
+::: details Firewall Warnings
+On first run, your OS firewall may show a warning. Allow connections for:
+
+- **localhost** only
+- The specific port you're using (default: 3000)
+  :::
+
+::: details Token Refresh Errors
+For MCP apps with token refresh issues:
+
+```typescript
+const authProvider = browserAuth({
+  store: fileStore(), // Use persistent storage
+  authTimeout: 300000, // Increase timeout to 5 minutes
+});
+```
+
+:::
+
+## Getting Help
+
+Need assistance? Here are your options:
+
+- 📝 [GitHub Issues](https://github.com/kriasoft/oauth-callback/issues) - Report bugs or request features
+- 💬 [GitHub Discussions](https://github.com/kriasoft/oauth-callback/discussions) - Ask questions and share ideas
+- 💬 [Discord Community](https://discord.gg/zQQXyqvs5x) - Join our Discord server for real-time help and discussions
+- 📚 [Stack Overflow](https://stackoverflow.com/questions/tagged/oauth-callback) - Search or ask questions with the `oauth-callback` tag
+
+Happy coding! 🚀

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,105 @@
+---
+# https://vitepress.dev/reference/default-theme-home-page
+layout: home
+
+hero:
+  name: "OAuth flow for your CLI or Node.js app"
+  text: ""
+  tagline: "Lightweight, cross-runtime, with native MCP SDK integration for AI agents"
+  image:
+    src: https://raw.githubusercontent.com/kriasoft/oauth-callback/main/examples/notion.gif
+    alt: OAuth Callback Demo
+  actions:
+    - theme: brand
+      text: Get Started
+      link: /getting-started
+    - theme: alt
+      text: View on GitHub
+      link: https://github.com/kriasoft/oauth-callback
+
+features:
+  - icon: 🚀
+    title: Multi-Runtime Support
+    details: Works seamlessly across Node.js 18+, Deno, and Bun. Write once, run anywhere with modern Web Standards APIs.
+  - icon: 🤖
+    title: MCP SDK Integration
+    details: Built-in OAuth provider for Model Context Protocol. Enable AI agents with secure authentication using browserAuth().
+  - icon: ⚡
+    title: Zero Configuration
+    details: Automatic localhost server setup, browser launching, and cleanup. Just pass your OAuth URL and get the auth code.
+  - icon: 📘
+    title: TypeScript First
+    details: Full TypeScript support with comprehensive types. Get IntelliSense and type safety throughout your OAuth flows.
+  - icon: 💾
+    title: Flexible Token Storage
+    details: Choose between ephemeral in-memory storage or persistent file-based tokens. Perfect for both CLI tools and long-running apps.
+  - icon: 🛡️
+    title: Production Ready
+    details: Battle-tested error handling with OAuthError class, customizable templates, and timeout protection. Handle real-world OAuth scenarios.
+---
+
+## Quick Start
+
+::: code-group
+
+```typescript [Basic Usage]
+import { getAuthCode } from "oauth-callback";
+
+// Just pass your OAuth URL - that's it!
+const result = await getAuthCode(
+  "https://github.com/login/oauth/authorize?client_id=xxx",
+);
+
+console.log("Auth code:", result.code);
+```
+
+```typescript [MCP Integration]
+import { browserAuth, inMemoryStore } from "oauth-callback/mcp";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+
+// OAuth provider for Notion MCP server
+// See: https://developers.notion.com/docs/get-started-with-mcp
+const authProvider = browserAuth({
+  store: inMemoryStore(), // Ephemeral tokens (lost on restart)
+});
+
+// Connect to Notion's MCP server with OAuth
+const transport = new StreamableHTTPClientTransport(
+  new URL("https://mcp.notion.com/mcp"),
+  { authProvider },
+);
+
+const client = new Client(
+  { name: "my-app", version: "1.0.0" },
+  { capabilities: {} },
+);
+
+await client.connect(transport);
+// Now you can use Notion's MCP tools!
+```
+
+```bash [Installation]
+# Using Bun (recommended)
+bun add oauth-callback
+
+# Using npm
+npm install oauth-callback
+
+# Using pnpm
+pnpm add oauth-callback
+```
+
+:::
+
+<div style="margin-top: 2rem; text-align: center;">
+  <a href="https://www.npmjs.com/package/oauth-callback" target="_blank">
+    <img src="https://img.shields.io/npm/v/oauth-callback.svg" alt="npm version" style="display: inline-block; margin: 0 0.5rem;">
+  </a>
+  <a href="https://www.npmjs.com/package/oauth-callback" target="_blank">
+    <img src="https://img.shields.io/npm/dm/oauth-callback.svg" alt="npm downloads" style="display: inline-block; margin: 0 0.5rem;">
+  </a>
+  <a href="https://github.com/kriasoft/oauth-callback/blob/main/LICENSE" target="_blank">
+    <img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="MIT License" style="display: inline-block; margin: 0 0.5rem;">
+  </a>
+</div>

--- a/docs/markdown-examples.md
+++ b/docs/markdown-examples.md
@@ -1,0 +1,85 @@
+# Markdown Extension Examples
+
+This page demonstrates some of the built-in markdown extensions provided by VitePress.
+
+## Syntax Highlighting
+
+VitePress provides Syntax Highlighting powered by [Shiki](https://github.com/shikijs/shiki), with additional features like line-highlighting:
+
+**Input**
+
+````md
+```js{4}
+export default {
+  data () {
+    return {
+      msg: 'Highlighted!'
+    }
+  }
+}
+```
+````
+
+**Output**
+
+```js{4}
+export default {
+  data () {
+    return {
+      msg: 'Highlighted!'
+    }
+  }
+}
+```
+
+## Custom Containers
+
+**Input**
+
+```md
+::: info
+This is an info box.
+:::
+
+::: tip
+This is a tip.
+:::
+
+::: warning
+This is a warning.
+:::
+
+::: danger
+This is a dangerous warning.
+:::
+
+::: details
+This is a details block.
+:::
+```
+
+**Output**
+
+::: info
+This is an info box.
+:::
+
+::: tip
+This is a tip.
+:::
+
+::: warning
+This is a warning.
+:::
+
+::: danger
+This is a dangerous warning.
+:::
+
+::: details
+This is a details block.
+:::
+
+## More
+
+Check out the documentation for the [full list of markdown extensions](https://vitepress.dev/guide/markdown).

--- a/docs/public/CNAME
+++ b/docs/public/CNAME
@@ -1,0 +1,1 @@
+kriasoft.com

--- a/docs/what-is-oauth-callback.md
+++ b/docs/what-is-oauth-callback.md
@@ -1,0 +1,346 @@
+---
+title: What is OAuth Callback?
+description: Learn how OAuth Callback simplifies OAuth 2.0 authorization code capture for CLI tools, desktop apps, and MCP clients using localhost callbacks.
+---
+
+# What is OAuth Callback? {#top}
+
+An OAuth callback is the mechanism that allows OAuth 2.0 authorization servers to return authorization codes to your application after user authentication. For native applications like CLI tools, desktop apps, and MCP clients, receiving this callback requires spinning up a temporary HTTP server on localhost — a process that **OAuth Callback** makes trivially simple with just one function call.
+
+**OAuth Callback** is designed for developers building CLI tools, desktop applications, automation scripts, and Model Context Protocol (MCP) clients that need to capture OAuth authorization codes via a localhost callback. Whether you're automating workflows across services (Notion, Linear, GitHub), building developer tools, or creating MCP-enabled applications, **OAuth Callback** handles the complexity of the loopback redirect flow recommended by [RFC 8252](https://www.rfc-editor.org/rfc/rfc8252.html) while providing modern features like Dynamic Client Registration and flexible token storage — all with support for Node.js 18+, Deno, and Bun.
+
+## Understanding OAuth Callbacks
+
+### What is a Callback URL in OAuth 2.0?
+
+In the OAuth 2.0 authorization code flow, the callback URL (also called redirect URI) is where the authorization server sends the user's browser after they approve or deny your application's access request. This URL receives critical information:
+
+- **On success**: An authorization `code` parameter that your app exchanges for access tokens
+- **On failure**: An `error` parameter describing what went wrong
+- **Security parameters**: The `state` value for CSRF protection
+
+For web applications, this callback is typically a route on your server. But for native applications without a public web server, you need a different approach.
+
+### The Loopback Redirect Pattern
+
+Native applications (CLIs, desktop apps) can't expose public URLs for callbacks. Instead, they use the **loopback interface** — a temporary HTTP server on `http://localhost` or `http://127.0.0.1`. This pattern, standardized in [RFC 8252](https://www.rfc-editor.org/rfc/rfc8252.html) (OAuth 2.0 for Native Apps), provides several benefits:
+
+- **No public exposure**: The callback server only accepts local connections
+- **Dynamic ports**: Apps can use any available port (e.g., 3000, 8080)
+- **Automatic cleanup**: The server shuts down immediately after receiving the callback
+- **Universal support**: Works across all platforms without special permissions
+
+Here's how the flow works:
+
+```mermaid
+sequenceDiagram
+    participant App as CLI/Desktop App
+    participant Browser as User's Browser
+    participant Auth as Authorization Server
+    participant Local as localhost:3000
+
+    App->>Local: Start HTTP server
+    App->>Browser: Open authorization URL
+    Browser->>Auth: Request authorization
+    Auth->>Browser: Show consent screen
+    Browser->>Auth: User approves
+    Auth->>Browser: Redirect to localhost:3000/callback?code=xyz
+    Browser->>Local: GET /callback?code=xyz
+    Local->>App: Capture code
+    App->>Local: Shutdown server
+    Local->>Browser: Show success page
+```
+
+### Security Best Practices
+
+OAuth 2.0 for native apps requires additional security measures:
+
+**Proof Key for Code Exchange (PKCE)** - [RFC 7636](https://www.rfc-editor.org/rfc/rfc7636.html) mandates using PKCE for public clients (those without client secrets). PKCE prevents authorization code interception attacks by binding the code exchange to a cryptographic challenge.
+
+```mermaid
+sequenceDiagram
+    participant App as Native App
+    participant Browser
+    participant Auth as Auth Server
+
+    Note over App: Generate code_verifier
+    Note over App: Hash to create code_challenge
+
+    App->>Browser: Open /authorize?code_challenge=...
+    Browser->>Auth: Authorization request with challenge
+    Auth->>Auth: Store challenge
+    Auth->>Browser: Redirect with code
+    Browser->>App: Return code
+
+    App->>Auth: POST /token with code + verifier
+    Auth->>Auth: Verify: hash(verifier) == challenge
+    Auth->>App: Return access token
+```
+
+**State Parameter** - A random value that prevents CSRF attacks. Your app generates this value, includes it in the authorization request, and validates it in the callback.
+
+**Dynamic Client Registration (DCR)** - [RFC 7591](https://www.rfc-editor.org/rfc/rfc7591.html) allows apps to register OAuth clients on-the-fly without pre-configuration. This is particularly useful for MCP servers where users shouldn't need to manually register OAuth applications.
+
+## How OAuth Callback Solves It
+
+OAuth Callback eliminates the boilerplate of implementing loopback redirects. Instead of manually managing servers, ports, and browser launches, you get a complete solution in one function call.
+
+### Core Functionality
+
+The library handles the entire OAuth callback flow:
+
+1. **Starts a localhost HTTP server** on your specified port
+2. **Opens the user's browser** to the authorization URL
+3. **Captures the callback** with the authorization code
+4. **Returns the result** as a clean JavaScript object
+5. **Shuts down the server** automatically
+
+### Zero Configuration Example
+
+Here's a complete OAuth flow in just 6 lines:
+
+```typescript {3-5}
+import { getAuthCode } from "oauth-callback";
+
+const result = await getAuthCode(
+  "https://github.com/login/oauth/authorize?client_id=xxx&redirect_uri=http://localhost:3000/callback",
+);
+
+console.log("Authorization code:", result.code);
+```
+
+That's it. No server setup, no browser management, no cleanup code.
+
+### Cross-Runtime Support
+
+OAuth Callback uses modern Web Standards APIs (Request, Response, URL) that work identically across:
+
+- **Node.js 18+** - Native fetch and Web Streams support
+- **Deno** - First-class Web Standards implementation
+- **Bun** - High-performance runtime with built-in APIs
+
+This means your OAuth code is portable across runtimes without modifications.
+
+### MCP Integration
+
+For Model Context Protocol applications, OAuth Callback provides the `browserAuth()` provider that integrates seamlessly with the MCP SDK:
+
+::: code-group
+
+```typescript [MCP with OAuth Callback]
+import { browserAuth, fileStore } from "oauth-callback/mcp";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+
+const authProvider = browserAuth({
+  store: fileStore(), // Persist tokens to ~/.mcp/tokens.json
+  scope: "read write",
+});
+
+// Use directly with MCP transports
+const transport = new StreamableHTTPClientTransport(
+  new URL("https://mcp.example.com"),
+  { authProvider },
+);
+```
+
+```typescript [Namespace Import]
+import { mcp } from "oauth-callback";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+
+const authProvider = mcp.browserAuth({
+  store: mcp.fileStore(),
+  scope: "read write",
+});
+```
+
+:::
+
+::: tip MCP Integration Features
+The MCP integration handles:
+
+- **Dynamic Client Registration** when supported by the server
+- **Token persistence** with `fileStore()` or ephemeral `inMemoryStore()`
+- **Automatic token refresh** when tokens expire
+- **Multiple app namespace support** via `storeKey` option
+  :::
+
+## When to Use OAuth Callback
+
+### Perfect For
+
+OAuth Callback is ideal when:
+
+- **You control the user's machine** - CLI tools, desktop apps, development tools
+- **You can open a browser** - The user has a default browser configured
+- **You need quick setup** - No server infrastructure or complex configuration
+- **You're building MCP clients** - Direct integration with Model Context Protocol SDK
+
+### Consider Alternatives When
+
+**Device Authorization Flow** ([RFC 8628](https://www.rfc-editor.org/rfc/rfc8628.html)) might be better if:
+
+- **No browser access** - SSH sessions, headless servers, CI/CD environments
+- **Remote terminals** - The auth happens on a different device than the app
+- **Input-constrained devices** - Smart TVs, IoT devices without keyboards
+
+The Device Flow shows a code to the user that they enter on another device, eliminating the need for a browser on the same machine. However, it requires OAuth provider support and a more complex user experience.
+
+```mermaid
+flowchart TD
+    subgraph "OAuth Callback Flow"
+        A1[CLI App] -->|Opens browser| B1[Auth Page]
+        B1 -->|User authorizes| C1[localhost:3000/callback]
+        C1 -->|Returns code| A1
+        A1 -->|Exchange code| D1[Access Token]
+    end
+
+    subgraph "Device Authorization Flow"
+        A2[CLI App] -->|Request device code| B2[Auth Server]
+        B2 -->|Returns code + URL| A2
+        A2 -->|Display to user| C2["User Code: ABCD-1234"]
+        C2 -->|User enters on phone/laptop| D2[Auth Page]
+        D2 -->|User authorizes| E2[Auth Server]
+        A2 -->|Poll for token| E2
+        E2 -->|Returns token| F2[Access Token]
+    end
+```
+
+## Security Considerations
+
+OAuth Callback implements security best practices by default:
+
+::: info Security Features
+
+- **Localhost-only binding** - The callback server only accepts connections from `127.0.0.1` or `::1`, preventing remote access attempts.
+- **Automatic cleanup** - The HTTP server shuts down immediately after receiving the callback, minimizing the attack surface window.
+- **No persistent state** - Server is ephemeral and leaves no traces after completion.
+
+:::
+
+::: warning Always Validate State
+Always validate the `state` parameter returned in the callback matches what you sent:
+
+```typescript {4-7}
+const state = crypto.randomUUID();
+const authUrl = `https://example.com/authorize?state=${state}&...`;
+
+const result = await getAuthCode(authUrl);
+if (result.state !== state) {
+  throw new Error("State mismatch - possible CSRF attack");
+}
+```
+
+:::
+
+::: details Proof Key for Code Exchange (PKCE) Implementation
+For public clients, implement Proof Key for Code Exchange as required by [RFC 7636](https://www.rfc-editor.org/rfc/rfc7636.html):
+
+```typescript {3-4,7,10}
+import { createHash, randomBytes } from "crypto";
+
+const verifier = randomBytes(32).toString("base64url");
+const challenge = createHash("sha256").update(verifier).digest("base64url");
+
+// Include challenge in authorization request
+const authUrl = `https://example.com/authorize?code_challenge=${challenge}&code_challenge_method=S256&...`;
+
+// Include verifier in token exchange
+const tokenResponse = await fetch(tokenUrl, {
+  method: "POST",
+  body: new URLSearchParams({
+    code: result.code,
+    code_verifier: verifier,
+    // ... other parameters
+  }),
+});
+```
+
+:::
+
+**Token storage choices** - Choose storage based on your security requirements:
+
+::: code-group
+
+```typescript [Ephemeral Storage]
+// Tokens lost on restart (more secure)
+import { browserAuth, inMemoryStore } from "oauth-callback/mcp";
+
+const authProvider = browserAuth({
+  store: inMemoryStore(),
+});
+```
+
+```typescript [Persistent Storage]
+// Tokens saved to disk (convenient)
+import { browserAuth, fileStore } from "oauth-callback/mcp";
+
+const authProvider = browserAuth({
+  store: fileStore("~/.myapp/tokens.json"),
+});
+```
+
+:::
+
+## Requirements and Registration
+
+### Prerequisites
+
+::: details System Requirements
+
+| Requirement           | Details                                                          |
+| --------------------- | ---------------------------------------------------------------- |
+| **Runtime**           | Node.js 18+, Deno, or Bun                                        |
+| **OAuth Application** | Register your app with the OAuth provider                        |
+| **Redirect URI**      | Configure `http://localhost:3000/callback` (or your chosen port) |
+| **Browser**           | User must have a default browser configured                      |
+| **Permissions**       | Ability to bind to localhost ports                               |
+
+:::
+
+### Standard OAuth Registration
+
+Most OAuth providers require pre-registering your application:
+
+1. Create an OAuth app in the provider's developer console
+2. Set redirect URI to `http://localhost:3000/callback`
+3. Copy your client ID (and secret if provided)
+4. Use credentials in your code
+
+### Dynamic Client Registration for MCP
+
+Some MCP servers support Dynamic Client Registration ([RFC 7591](https://www.rfc-editor.org/rfc/rfc7591.html)), eliminating pre-registration:
+
+::: tip No Pre-Registration Required
+
+```typescript {1}
+// No client_id or client_secret needed!
+const authProvider = browserAuth({
+  scope: "read write",
+  store: fileStore(),
+});
+```
+
+:::
+
+The Notion MCP example demonstrates this — the server automatically registers your client on first use. This greatly simplifies distribution of MCP-enabled tools.
+
+```mermaid
+flowchart LR
+    subgraph "Traditional OAuth Setup"
+        A[Developer] -->|1 Register app| B[OAuth Provider]
+        B -->|2 Get client_id| A
+        A -->|3 Embed client_id in app| D[CLI App]
+        A -->|4 Distribute app| C[User]
+        C -->|5 Runs app to authenticate| D
+    end
+
+    subgraph "Dynamic Client Registration"
+        E[User] -->|1 Run app| F[CLI App]
+        F -->|2 Auto-register| G[OAuth Provider]
+        G -->|3 Return credentials| F
+        F -->|4 Complete auth| H[Ready to use!]
+    end
+
+    style H fill:#3498DB
+```

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "type": "git",
     "url": "git+https://github.com/kriasoft/oauth-callback.git"
   },
-  "homepage": "https://github.com/kriasoft/oauth-callback",
+  "homepage": "https://kriasoft.com/oauth-callback",
   "bugs": {
     "url": "https://github.com/kriasoft/oauth-callback/issues"
   },
@@ -81,9 +81,12 @@
   "devDependencies": {
     "@modelcontextprotocol/sdk": "^1.17.3",
     "@types/bun": "^1.2.20",
+    "mermaid": "^11.9.0",
     "prettier": "^3.6.2",
     "publint": "^0.3.12",
-    "typescript": "^5.9.2"
+    "typescript": "^5.9.2",
+    "vitepress": "^1.6.4",
+    "vitepress-plugin-mermaid": "^2.0.17"
   },
   "prettier": {
     "trailingComma": "all",
@@ -106,6 +109,10 @@
     "example:github": "bun run examples/github.ts",
     "example:notion": "bun run examples/notion.ts",
     "example:mcp-auth": "bun run examples/mcp-auth.ts",
-    "prepublishOnly": "bun run build && bun run lint:package"
+    "prepublishOnly": "bun run build && bun run lint:package",
+    "docs:dev": "vitepress dev docs",
+    "docs:build": "vitepress build docs",
+    "docs:preview": "vitepress preview docs",
+    "docs:publish": "bunx gh-pages -d docs/.vitepress/dist"
   }
 }


### PR DESCRIPTION
## Summary

This PR introduces a complete documentation site for the oauth-callback library using VitePress. The documentation provides comprehensive guides, API references, and examples to help developers integrate OAuth authentication into their CLI tools, desktop applications, and MCP clients.

## What's Included

### Documentation Structure
- **Introduction Section**
  - What is OAuth Callback - Overview and use cases
  - Getting Started - Quick start guide with installation and basic usage
  - Core Concepts - Architecture, OAuth flow patterns, and design decisions

### API Reference
- **Core Functions**
  - `getAuthCode` - Complete reference for OAuth authorization code capture
  - `browserAuth` - MCP SDK-compatible OAuth provider documentation
  
- **Storage Providers**
  - `inMemoryStore` - Ephemeral token storage
  - `fileStore` - Persistent file-based storage
  - Storage interfaces and custom implementation guide

- **Error Handling**
  - `OAuthError` class documentation
  - Common error codes and handling patterns

- **TypeScript Types**
  - Complete type definitions reference
  - Interface documentation

### Examples
- **Notion MCP Integration** - Comprehensive example showing Dynamic Client Registration (DCR) with the Notion Model Context Protocol server

### Features
- 🎨 Clean, modern documentation design with VitePress default theme
- 📊 Mermaid diagram support for visualizing OAuth flows
- 🔍 Local search functionality
- 📱 Responsive design for mobile and desktop
- 🔗 GitHub edit links for community contributions
- 📦 Automated deployment to GitHub Pages

## Changes Made

1. **Added VitePress framework** with configuration for GitHub Pages deployment
2. **Created comprehensive documentation** covering all library features
3. **Fixed documentation issues**:
   - Updated expired Discord invite link
   - Removed reference to non-existent Linear example
   - Removed undocumented TimeoutError reference
4. **Added development documentation** - docs:dev script reference in README
5. **Configured build process** for documentation site

## Testing

To test the documentation locally:

```bash
# Install dependencies
bun install

# Run documentation dev server
bun run docs:dev

# Build documentation
bun run docs:build

# Preview production build
bun run docs:preview
```

The documentation is available at http://localhost:5173 when running the dev server.

## Deployment

The documentation is configured for GitHub Pages deployment at `/oauth-callback/` base path. After merging, run:

```bash
bun run docs:publish
```

## Screenshots

The documentation includes:
- Clean landing page with feature highlights
- Organized sidebar navigation
- API reference with code examples
- Interactive Mermaid diagrams for OAuth flows
- Responsive design for all screen sizes