### PR TITLE
Shutdown NodeCallbackServer gracefully

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -285,6 +285,8 @@ class NodeCallbackServer extends BaseCallbackServer {
           const request = this.nodeToWebRequest(req, port, hostname);
           const response = this.handleRequest(request);
 
+          res.shouldKeepAlive = false;
+
           res.writeHead(
             response.status,
             Object.fromEntries(response.headers.entries()),
@@ -308,7 +310,6 @@ class NodeCallbackServer extends BaseCallbackServer {
 
   protected async stopServer(): Promise<void> {
     if (!this.server) return;
-    this.server.closeAllConnections();
     return new Promise((resolve) => {
       this.server?.close(() => {
         this.server = undefined;

--- a/src/server.ts
+++ b/src/server.ts
@@ -162,36 +162,36 @@ abstract class BaseCallbackServer implements CallbackServer {
     path: string,
     timeout: number,
   ): Promise<CallbackResult> {
-    if (this.callbackListeners.has(path))
+    if (!path) throw new Error("Callback path is required");
+    const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+
+    if (this.callbackListeners.has(normalizedPath))
       return Promise.reject(
-        new Error(`A listener for the path "${path}" is already active.`),
+        new Error(
+          `A listener for the path "${normalizedPath}" is already active.`,
+        ),
       );
 
     let timeoutId: ReturnType<typeof setTimeout> | undefined;
 
     try {
-      // Race a promise that waits for the callback against a promise that rejects on timeout.
       return await Promise.race([
-        // This promise is resolved or rejected by the handleRequest method.
         new Promise<CallbackResult>((resolve, reject) => {
-          this.callbackListeners.set(path, { resolve, reject });
+          this.callbackListeners.set(normalizedPath, { resolve, reject });
         }),
-        // This promise rejects after the specified timeout.
         new Promise<CallbackResult>((_, reject) => {
           timeoutId = setTimeout(() => {
             reject(
               new TimeoutError(
-                `OAuth callback timeout after ${timeout}ms waiting for ${path}`,
+                `OAuth callback timeout after ${timeout}ms waiting for ${normalizedPath}`,
               ),
             );
           }, timeout);
         }),
       ]);
     } finally {
-      // CRITICAL: Always clean up the listener and timeout to prevent memory leaks
-      // and allow the process to exit cleanly.
       if (timeoutId) clearTimeout(timeoutId);
-      this.callbackListeners.delete(path);
+      this.callbackListeners.delete(normalizedPath);
     }
   }
 
@@ -251,11 +251,6 @@ class DenoCallbackServer extends BaseCallbackServer {
     const { port, hostname = "localhost" } = options;
     this.abortController = new AbortController();
 
-    // The user's signal will abort our internal controller.
-    options.signal?.addEventListener("abort", () =>
-      this.abortController?.abort(),
-    );
-
     Deno.serve(
       { port, hostname, signal: this.abortController.signal },
       (request: Request) => this.handleRequest(request),
@@ -294,15 +289,11 @@ class NodeCallbackServer extends BaseCallbackServer {
           );
           const body = await response.text();
           res.end(body);
-        } catch (error) {
+        } catch {
           res.writeHead(500);
           res.end("Internal Server Error");
         }
       });
-
-      // Tie server closing to the abort signal if provided.
-      if (options.signal)
-        options.signal.addEventListener("abort", () => this.server?.close());
 
       this.server.listen(port, hostname, () => resolve());
       this.server.on("error", reject);


### PR DESCRIPTION
- Previously the response was not fully flushed when we called closeAllConnections as this closes all connections forcefully, but without it the response had a `Connection: keep-alive` header, this fixes the issue by properly setting the response header to `Connection: close` and removes the forceful connection closing
- Fixes: https://github.com/kriasoft/oauth-callback/issues/25

### Additional cleanup

- Unified abort handling: removed redundant signal listeners from Node/Deno runtimes; `BaseCallbackServer` now exclusively owns abort lifecycle
- Normalize callback paths (prepend `/` if missing, reject empty string)

### Testing

1. Added this sample script: `examples/demo-node.js`
```js
import { getAuthCode } from "../dist/index.js";

const result = await getAuthCode({
  authorizationUrl: "https://github.com",
  port: 1234,
  openBrowser: true,
  timeout: 5 * 60 * 1000, // 5 minutes
});

console.log(result);
```

2. Used this to run: `npm run build && node examples/demo-node.js`
3. Opened this page manually: `http://localhost:1234/callback?code=123&status=456`

**Before**
<img width="779" height="520" alt="Screenshot 2026-01-23 at 12 49 50" src="https://github.com/user-attachments/assets/ff182b54-5923-4101-8904-0f75caeba7f5" />
<img width="1425" height="344" alt="Screenshot 2026-01-23 at 12 49 58" src="https://github.com/user-attachments/assets/5505d7bb-b073-4dff-9fba-2b3eb3dadaef" />

**After**
<img width="741" height="368" alt="Screenshot 2026-01-23 at 12 51 17" src="https://github.com/user-attachments/assets/5ef811ff-683c-40e1-8fd2-53d362ea699d" />
<img width="1432" height="267" alt="Screenshot 2026-01-23 at 12 51 25" src="https://github.com/user-attachments/assets/5bf00fb7-8f90-4158-9b20-eb5f1a5a9198" />