### PR TITLE
Replace openBrowser with explicit launch callback

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,46 @@
+# Contributing
+
+## Setup
+
+```bash
+git clone https://github.com/kriasoft/oauth-callback.git
+cd oauth-callback
+bun install
+```
+
+## Development
+
+```bash
+bun run build         # Build the package
+bun run test          # Run unit tests
+bun run typecheck     # Check TypeScript types
+bun run validate      # Run all checks (format, typecheck, test, publint)
+```
+
+## Testing Locally
+
+```bash
+bun run example:demo  # Interactive demo with mock OAuth server
+bun run test:login    # Manual browser test for page rendering
+```
+
+## Pull Requests
+
+- Keep changes focused and minimal
+- Run `bun run validate` before submitting
+- Use clear commit messages that explain the "why"
+
+## Project Structure
+
+- `src/` - Source code
+- `templates/` - HTML templates (run `bun run build:templates` after changes)
+- `examples/` - Usage examples
+- `docs/` - Documentation site (VitePress)
+
+## Questions?
+
+Open an issue or join us on [Discord](https://discord.gg/bSsv7XM).
+
+## Maintainers Wanted
+
+We're looking for project maintainers! If you're interested in helping maintain this project, reach out on Discord or open an issue.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -159,18 +159,3 @@ jobs:
           prerelease: ${{ contains(github.ref_name, '-') }}
           files: |
             dist/**/*
-
-  lint:
-    name: Lint
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v6
-      - name: Lint YAML and JSON
-        uses: github/super-linter/slim@v7
-        env:
-          DEFAULT_BRANCH: main
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VALIDATE_JSON: true
-          VALIDATE_YAML: true
-          FILTER_REGEX_EXCLUDE: node_modules/.*|dist/.*|bun\.lock

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,65 +21,44 @@ jobs:
         os: [ubuntu-latest, macos-latest]
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v5
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+      - uses: actions/checkout@v6
+      - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
-
-      - name: Build templates
-        run: bun run build:templates
-
-      - name: Run tests
-        run: bun test
-
-      - name: Type check
+      - uses: actions/cache@v5
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+      - run: bun install --frozen-lockfile
+      - run: bun run build:templates
+      - run: bun test
+      - run: bun run typecheck
         if: matrix.os == 'ubuntu-latest'
-        run: bun run typecheck
 
   build:
     name: Build & Validate
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v5
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+      - uses: actions/checkout@v6
+      - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
-
-      - name: Cache dependencies
-        uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
           restore-keys: |
             ${{ runner.os }}-bun-
 
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
-
-      - name: Check formatting
-        run: bun run format:check
-
-      - name: Type check
-        run: bun run typecheck
-
-      - name: Build templates
-        run: bun templates/build.ts
-
-      - name: Build package
-        run: bun run build
-
-      - name: Validate package
-        run: bun run lint:package
+      - run: bun install --frozen-lockfile
+      - run: bun run format:check
+      - run: bun run typecheck
+      - run: bun run build:templates
+      - run: bun run build
+      - run: bun run lint:package
 
       - name: Check dist output
         run: |
@@ -93,8 +72,7 @@ jobs:
           fi
           echo "✅ Build output verified"
 
-      - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: dist
           path: dist/
@@ -106,25 +84,22 @@ jobs:
     needs: build
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v5
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+      - uses: actions/checkout@v6
+      - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
-
-      - name: Download build artifacts
-        uses: actions/download-artifact@v5
+      - uses: actions/cache@v5
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+      - run: bun install --frozen-lockfile
+      - uses: actions/download-artifact@v6
         with:
           name: dist
           path: dist/
-
-      - name: Test demo example (dry run)
-        run: bun run examples/demo.ts --no-browser
+      - run: bun run examples/demo.ts --no-browser
         timeout-minutes: 1
 
       - name: Check example files
@@ -149,25 +124,16 @@ jobs:
       id-token: write
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v5
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
-
-      - name: Build package
-        run: |
+      - run: bun install --frozen-lockfile
+      - run: |
           bun run build:templates
           bun run build
 
@@ -181,13 +147,11 @@ jobs:
           fi
           echo "✅ Version verified: $PACKAGE_VERSION"
 
-      - name: Publish to NPM
-        run: npm publish --provenance --access public
+      - run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+      - uses: softprops/action-gh-release@v2
         with:
           name: Release ${{ github.ref_name }}
           generate_release_notes: true
@@ -196,24 +160,17 @@ jobs:
           files: |
             dist/**/*
 
-  security:
-    name: Security Scan
+  lint:
+    name: Lint
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' || github.event_name == 'push'
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-
-      - name: Run Dependabot security scan
+      - uses: actions/checkout@v6
+      - name: Lint YAML and JSON
         uses: github/super-linter/slim@v7
         env:
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VALIDATE_JAVASCRIPT_ES: true
-          VALIDATE_TYPESCRIPT_ES: true
           VALIDATE_JSON: true
           VALIDATE_YAML: true
-          FILTER_REGEX_EXCLUDE: .*node_modules/.*|.*dist/.*|.*bun.lock|.*tsconfig\.json
+          FILTER_REGEX_EXCLUDE: node_modules/.*|dist/.*|bun\.lock

--- a/README.md
+++ b/README.md
@@ -451,13 +451,9 @@ If the browser doesn't open automatically, manually navigate to the authorizatio
 
 ## Contributing
 
-Contributions are welcome! Please feel free to submit a Pull Request.
+Contributions are welcome! See [CONTRIBUTING.md](.github/CONTRIBUTING.md) for setup instructions.
 
-1. Fork the repository
-2. Create your feature branch (`git checkout -b feature/amazing-feature`)
-3. Commit your changes (`git commit -m 'Add some amazing feature'`)
-4. Push to the branch (`git push origin feature/amazing-feature`)
-5. Open a Pull Request
+**Maintainers wanted** — we're looking for people to help maintain this project. If interested, reach out on [Discord](https://discord.gg/bSsv7XM) or open an issue.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,10 @@ async function authenticate() {
     });
 
   try {
-    const result = await getAuthCode({ authorizationUrl: authUrl, launch: open });
+    const result = await getAuthCode({
+      authorizationUrl: authUrl,
+      launch: open,
+    });
     console.log("Authorization code:", result.code);
     console.log("State:", result.state);
 
@@ -431,7 +434,11 @@ bun run example:notion  # Notion MCP example with Dynamic Client Registration
 If port 3000 is already in use, specify a different port:
 
 ```typescript
-const result = await getAuthCode({ authorizationUrl: authUrl, launch: open, port: 8080 });
+const result = await getAuthCode({
+  authorizationUrl: authUrl,
+  launch: open,
+  port: 8080,
+});
 ```
 
 ### Firewall Warnings

--- a/README.md
+++ b/README.md
@@ -31,33 +31,38 @@ A lightweight OAuth 2.0 callback handler for Node.js, Deno, and Bun with built-i
 ## Installation
 
 ```bash
-bun add oauth-callback
+bun add oauth-callback open
 ```
 
 Or with npm:
 
 ```bash
-npm install oauth-callback
+npm install oauth-callback open
 ```
+
+> **Note:** The `open` package is optional but recommended for browser launching. If using pnpm, install it explicitly: `pnpm add open`
 
 ## Quick Start
 
 ```typescript
+import open from "open";
 import { getAuthCode, OAuthError } from "oauth-callback";
 
-// Simple usage
-const result = await getAuthCode(
-  "https://example.com/oauth/authorize?client_id=xxx&redirect_uri=http://localhost:3000/callback",
-);
+// Simple usage - pass `open` to launch browser
+const result = await getAuthCode({
+  authorizationUrl:
+    "https://example.com/oauth/authorize?client_id=xxx&redirect_uri=http://localhost:3000/callback",
+  launch: open,
+});
 console.log("Authorization code:", result.code);
 
 // MCP SDK integration - use specific import
 import { browserAuth, fileStore } from "oauth-callback/mcp";
-const authProvider = browserAuth({ store: fileStore() });
+const authProvider = browserAuth({ launch: open, store: fileStore() });
 
 // Or via namespace import
 import { mcp } from "oauth-callback";
-const authProvider = mcp.browserAuth({ store: mcp.fileStore() });
+const authProvider = mcp.browserAuth({ launch: open, store: mcp.fileStore() });
 ```
 
 ## Usage Examples
@@ -65,6 +70,7 @@ const authProvider = mcp.browserAuth({ store: mcp.fileStore() });
 ### Basic OAuth Flow
 
 ```typescript
+import open from "open";
 import { getAuthCode, OAuthError } from "oauth-callback";
 
 async function authenticate() {
@@ -78,7 +84,7 @@ async function authenticate() {
     });
 
   try {
-    const result = await getAuthCode(authUrl);
+    const result = await getAuthCode({ authorizationUrl: authUrl, launch: open });
     console.log("Authorization code:", result.code);
     console.log("State:", result.state);
 
@@ -98,10 +104,12 @@ async function authenticate() {
 ### Custom Port Configuration
 
 ```typescript
+import open from "open";
 import { getAuthCode } from "oauth-callback";
 
 const result = await getAuthCode({
   authorizationUrl: authUrl,
+  launch: open,
   port: 8080, // Use custom port (default: 3000)
   timeout: 60000, // Custom timeout in ms (default: 30000)
 });
@@ -175,9 +183,12 @@ const authProvider = browserAuth({
 ### Advanced Usage
 
 ```typescript
+import open from "open";
+
 // With custom HTML templates and logging
 const result = await getAuthCode({
   authorizationUrl: authUrl,
+  launch: open,
   port: 3000,
   hostname: "127.0.0.1", // Bind to specific IP
   successHtml: "<h1>Success! You can close this window.</h1>",
@@ -209,7 +220,7 @@ try {
 
 ### `getAuthCode(input)`
 
-Starts a local HTTP server and opens the authorization URL in the user's browser.
+Starts a local HTTP server to capture OAuth callbacks. Optionally launches the authorization URL via the `launch` callback.
 
 #### Parameters
 
@@ -219,7 +230,7 @@ Starts a local HTTP server and opens the authorization URL in the user's browser
   - `hostname` (string): Hostname to bind the server to (default: "localhost")
   - `callbackPath` (string): URL path for the OAuth callback (default: "/callback")
   - `timeout` (number): Timeout in milliseconds (default: 30000)
-  - `openBrowser` (boolean): Whether to open browser automatically (default: true)
+  - `launch` (function): Optional callback to launch the authorization URL (e.g., `open`)
   - `successHtml` (string): Custom HTML to display on successful authorization
   - `errorHtml` (string): Custom HTML to display on authorization error
   - `signal` (AbortSignal): AbortSignal for cancellation support
@@ -311,7 +322,7 @@ TokenStore implementation for persistent token storage.
 ```
 
 1. **Server Creation** — Spins up a temporary localhost HTTP server
-2. **Browser Launch** — Opens the authorization URL in the default browser
+2. **Browser Launch** — Opens the authorization URL (if `launch` callback provided)
 3. **User Authorization** — User grants permission on the OAuth provider's page
 4. **Callback Capture** — Provider redirects to localhost with the authorization code
 5. **Cleanup** — Server closes automatically, code is returned to your app
@@ -420,7 +431,7 @@ bun run example:notion  # Notion MCP example with Dynamic Client Registration
 If port 3000 is already in use, specify a different port:
 
 ```typescript
-const result = await getAuthCode({ authorizationUrl: authUrl, port: 8080 });
+const result = await getAuthCode({ authorizationUrl: authUrl, launch: open, port: 8080 });
 ```
 
 ### Firewall Warnings

--- a/bun.lock
+++ b/bun.lock
@@ -4,22 +4,19 @@
   "workspaces": {
     "": {
       "name": "oauth-callback",
-      "dependencies": {
-        "open": "^11.0.0",
-      },
       "devDependencies": {
         "@modelcontextprotocol/sdk": "^1.25.3",
         "@types/bun": "^1.3.6",
         "@types/deno": "^2.5.0",
         "@types/node": "^25.0.10",
-        "@types/open": "^6.2.1",
         "bun-types": "^1.2.20",
         "mermaid": "^11.12.2",
+        "open": "^11.0.0",
         "prettier": "^3.8.1",
         "publint": "^0.3.17",
         "srcpack": "^0.1.13",
         "typescript": "^5.9.3",
-        "vitepress": "^1.6.4",
+        "vitepress": "^2.0.0-alpha.15",
         "vitepress-plugin-mermaid": "^2.0.17",
       },
       "peerDependencies": {
@@ -33,42 +30,6 @@
     },
   },
   "packages": {
-    "@algolia/abtesting": ["@algolia/abtesting@1.1.0", "", { "dependencies": { "@algolia/client-common": "5.35.0", "@algolia/requester-browser-xhr": "5.35.0", "@algolia/requester-fetch": "5.35.0", "@algolia/requester-node-http": "5.35.0" } }, "sha512-sEyWjw28a/9iluA37KLGu8vjxEIlb60uxznfTUmXImy7H5NvbpSO6yYgmgH5KiD7j+zTUUihiST0jEP12IoXow=="],
-
-    "@algolia/autocomplete-core": ["@algolia/autocomplete-core@1.17.7", "", { "dependencies": { "@algolia/autocomplete-plugin-algolia-insights": "1.17.7", "@algolia/autocomplete-shared": "1.17.7" } }, "sha512-BjiPOW6ks90UKl7TwMv7oNQMnzU+t/wk9mgIDi6b1tXpUek7MW0lbNOUHpvam9pe3lVCf4xPFT+lK7s+e+fs7Q=="],
-
-    "@algolia/autocomplete-plugin-algolia-insights": ["@algolia/autocomplete-plugin-algolia-insights@1.17.7", "", { "dependencies": { "@algolia/autocomplete-shared": "1.17.7" }, "peerDependencies": { "search-insights": ">= 1 < 3" } }, "sha512-Jca5Ude6yUOuyzjnz57og7Et3aXjbwCSDf/8onLHSQgw1qW3ALl9mrMWaXb5FmPVkV3EtkD2F/+NkT6VHyPu9A=="],
-
-    "@algolia/autocomplete-preset-algolia": ["@algolia/autocomplete-preset-algolia@1.17.7", "", { "dependencies": { "@algolia/autocomplete-shared": "1.17.7" }, "peerDependencies": { "@algolia/client-search": ">= 4.9.1 < 6", "algoliasearch": ">= 4.9.1 < 6" } }, "sha512-ggOQ950+nwbWROq2MOCIL71RE0DdQZsceqrg32UqnhDz8FlO9rL8ONHNsI2R1MH0tkgVIDKI/D0sMiUchsFdWA=="],
-
-    "@algolia/autocomplete-shared": ["@algolia/autocomplete-shared@1.17.7", "", { "peerDependencies": { "@algolia/client-search": ">= 4.9.1 < 6", "algoliasearch": ">= 4.9.1 < 6" } }, "sha512-o/1Vurr42U/qskRSuhBH+VKxMvkkUVTLU6WZQr+L5lGZZLYWyhdzWjW0iGXY7EkwRTjBqvN2EsR81yCTGV/kmg=="],
-
-    "@algolia/client-abtesting": ["@algolia/client-abtesting@5.35.0", "", { "dependencies": { "@algolia/client-common": "5.35.0", "@algolia/requester-browser-xhr": "5.35.0", "@algolia/requester-fetch": "5.35.0", "@algolia/requester-node-http": "5.35.0" } }, "sha512-uUdHxbfHdoppDVflCHMxRlj49/IllPwwQ2cQ8DLC4LXr3kY96AHBpW0dMyi6ygkn2MtFCc6BxXCzr668ZRhLBQ=="],
-
-    "@algolia/client-analytics": ["@algolia/client-analytics@5.35.0", "", { "dependencies": { "@algolia/client-common": "5.35.0", "@algolia/requester-browser-xhr": "5.35.0", "@algolia/requester-fetch": "5.35.0", "@algolia/requester-node-http": "5.35.0" } }, "sha512-SunAgwa9CamLcRCPnPHx1V2uxdQwJGqb1crYrRWktWUdld0+B2KyakNEeVn5lln4VyeNtW17Ia7V7qBWyM/Skw=="],
-
-    "@algolia/client-common": ["@algolia/client-common@5.35.0", "", {}, "sha512-ipE0IuvHu/bg7TjT2s+187kz/E3h5ssfTtjpg1LbWMgxlgiaZIgTTbyynM7NfpSJSKsgQvCQxWjGUO51WSCu7w=="],
-
-    "@algolia/client-insights": ["@algolia/client-insights@5.35.0", "", { "dependencies": { "@algolia/client-common": "5.35.0", "@algolia/requester-browser-xhr": "5.35.0", "@algolia/requester-fetch": "5.35.0", "@algolia/requester-node-http": "5.35.0" } }, "sha512-UNbCXcBpqtzUucxExwTSfAe8gknAJ485NfPN6o1ziHm6nnxx97piIbcBQ3edw823Tej2Wxu1C0xBY06KgeZ7gA=="],
-
-    "@algolia/client-personalization": ["@algolia/client-personalization@5.35.0", "", { "dependencies": { "@algolia/client-common": "5.35.0", "@algolia/requester-browser-xhr": "5.35.0", "@algolia/requester-fetch": "5.35.0", "@algolia/requester-node-http": "5.35.0" } }, "sha512-/KWjttZ6UCStt4QnWoDAJ12cKlQ+fkpMtyPmBgSS2WThJQdSV/4UWcqCUqGH7YLbwlj3JjNirCu3Y7uRTClxvA=="],
-
-    "@algolia/client-query-suggestions": ["@algolia/client-query-suggestions@5.35.0", "", { "dependencies": { "@algolia/client-common": "5.35.0", "@algolia/requester-browser-xhr": "5.35.0", "@algolia/requester-fetch": "5.35.0", "@algolia/requester-node-http": "5.35.0" } }, "sha512-8oCuJCFf/71IYyvQQC+iu4kgViTODbXDk3m7yMctEncRSRV+u2RtDVlpGGfPlJQOrAY7OONwJlSHkmbbm2Kp/w=="],
-
-    "@algolia/client-search": ["@algolia/client-search@5.35.0", "", { "dependencies": { "@algolia/client-common": "5.35.0", "@algolia/requester-browser-xhr": "5.35.0", "@algolia/requester-fetch": "5.35.0", "@algolia/requester-node-http": "5.35.0" } }, "sha512-FfmdHTrXhIduWyyuko1YTcGLuicVbhUyRjO3HbXE4aP655yKZgdTIfMhZ/V5VY9bHuxv/fGEh3Od1Lvv2ODNTg=="],
-
-    "@algolia/ingestion": ["@algolia/ingestion@1.35.0", "", { "dependencies": { "@algolia/client-common": "5.35.0", "@algolia/requester-browser-xhr": "5.35.0", "@algolia/requester-fetch": "5.35.0", "@algolia/requester-node-http": "5.35.0" } }, "sha512-gPzACem9IL1Co8mM1LKMhzn1aSJmp+Vp434An4C0OBY4uEJRcqsLN3uLBlY+bYvFg8C8ImwM9YRiKczJXRk0XA=="],
-
-    "@algolia/monitoring": ["@algolia/monitoring@1.35.0", "", { "dependencies": { "@algolia/client-common": "5.35.0", "@algolia/requester-browser-xhr": "5.35.0", "@algolia/requester-fetch": "5.35.0", "@algolia/requester-node-http": "5.35.0" } }, "sha512-w9MGFLB6ashI8BGcQoVt7iLgDIJNCn4OIu0Q0giE3M2ItNrssvb8C0xuwJQyTy1OFZnemG0EB1OvXhIHOvQwWw=="],
-
-    "@algolia/recommend": ["@algolia/recommend@5.35.0", "", { "dependencies": { "@algolia/client-common": "5.35.0", "@algolia/requester-browser-xhr": "5.35.0", "@algolia/requester-fetch": "5.35.0", "@algolia/requester-node-http": "5.35.0" } }, "sha512-AhrVgaaXAb8Ue0u2nuRWwugt0dL5UmRgS9LXe0Hhz493a8KFeZVUE56RGIV3hAa6tHzmAV7eIoqcWTQvxzlJeQ=="],
-
-    "@algolia/requester-browser-xhr": ["@algolia/requester-browser-xhr@5.35.0", "", { "dependencies": { "@algolia/client-common": "5.35.0" } }, "sha512-diY415KLJZ6x1Kbwl9u96Jsz0OstE3asjXtJ9pmk1d+5gPuQ5jQyEsgC+WmEXzlec3iuVszm8AzNYYaqw6B+Zw=="],
-
-    "@algolia/requester-fetch": ["@algolia/requester-fetch@5.35.0", "", { "dependencies": { "@algolia/client-common": "5.35.0" } }, "sha512-uydqnSmpAjrgo8bqhE9N1wgcB98psTRRQXcjc4izwMB7yRl9C8uuAQ/5YqRj04U0mMQ+fdu2fcNF6m9+Z1BzDQ=="],
-
-    "@algolia/requester-node-http": ["@algolia/requester-node-http@5.35.0", "", { "dependencies": { "@algolia/client-common": "5.35.0" } }, "sha512-RgLX78ojYOrThJHrIiPzT4HW3yfQa0D7K+MQ81rhxqaNyNBu4F1r+72LNHYH/Z+y9I1Mrjrd/c/Ue5zfDgAEjQ=="],
-
     "@antfu/install-pkg": ["@antfu/install-pkg@1.1.0", "", { "dependencies": { "package-manager-detector": "^1.3.0", "tinyexec": "^1.0.1" } }, "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ=="],
 
     "@babel/code-frame": ["@babel/code-frame@7.28.6", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-JYgintcMjRiCvS8mMECzaEn+m3PfoQiyqukOMCCVQtoJGYJw8j/8LBJEiqkHLkfwCcs74E3pbAUFNg7d9VNJ+Q=="],
@@ -77,9 +38,9 @@
 
     "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
 
-    "@babel/parser": ["@babel/parser@7.28.3", "", { "dependencies": { "@babel/types": "^7.28.2" }, "bin": "./bin/babel-parser.js" }, "sha512-7+Ey1mAgYqFAx2h0RuoxcQT5+MlG3GTV0TQrgr7/ZliKsm/MNDxVVutlWaziMq7wJNAz8MTqz55XLpWvva6StA=="],
+    "@babel/parser": ["@babel/parser@7.28.6", "", { "dependencies": { "@babel/types": "^7.28.6" }, "bin": "./bin/babel-parser.js" }, "sha512-TeR9zWR18BvbfPmGbLampPMW+uW1NZnJlRuuHso8i87QZNq2JRF9i6RgxRqtEq+wQGsS19NNTWr2duhnE49mfQ=="],
 
-    "@babel/types": ["@babel/types@7.28.2", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.27.1" } }, "sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ=="],
+    "@babel/types": ["@babel/types@7.28.6", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg=="],
 
     "@braintree/sanitize-url": ["@braintree/sanitize-url@7.1.1", "", {}, "sha512-i1L7noDNxtFyL5DmZafWy1wRVhGehQmzZaz1HiN5e7iylJMSZR7ekOV7NsIqa5qBldlLrsKv4HbgFUVlQrz8Mw=="],
 
@@ -97,63 +58,67 @@
 
     "@clack/prompts": ["@clack/prompts@0.11.0", "", { "dependencies": { "@clack/core": "0.5.0", "picocolors": "^1.0.0", "sisteransi": "^1.0.5" } }, "sha512-pMN5FcrEw9hUkZA4f+zLlzivQSeQf5dRGJjSUbvVYDLvpKCdQx5OaknvKzgbtXOizhP+SJJJjqEbOe55uKKfAw=="],
 
-    "@docsearch/css": ["@docsearch/css@3.8.2", "", {}, "sha512-y05ayQFyUmCXze79+56v/4HpycYF3uFqB78pLPrSV5ZKAlDuIAAJNhaRi8tTdRNXh05yxX/TyNnzD6LwSM89vQ=="],
+    "@docsearch/css": ["@docsearch/css@4.5.3", "", {}, "sha512-kUpHaxn0AgI3LQfyzTYkNUuaFY4uEz/Ym9/N/FvyDE+PzSgZsCyDH9jE49B6N6f1eLCm9Yp64J9wENd6vypdxA=="],
 
-    "@docsearch/js": ["@docsearch/js@3.8.2", "", { "dependencies": { "@docsearch/react": "3.8.2", "preact": "^10.0.0" } }, "sha512-Q5wY66qHn0SwA7Taa0aDbHiJvaFJLOJyHmooQ7y8hlwwQLQ/5WwCcoX0g7ii04Qi2DJlHsd0XXzJ8Ypw9+9YmQ=="],
+    "@docsearch/js": ["@docsearch/js@4.5.3", "", {}, "sha512-rcBiUMCXbZLqrLIT6F6FDcrG/tyvM2WM0zum6NPbIiQNDQxbSgmNc+/bToS0rxBsXaxiU64esiWoS02WqrWLsg=="],
 
-    "@docsearch/react": ["@docsearch/react@3.8.2", "", { "dependencies": { "@algolia/autocomplete-core": "1.17.7", "@algolia/autocomplete-preset-algolia": "1.17.7", "@docsearch/css": "3.8.2", "algoliasearch": "^5.14.2" }, "peerDependencies": { "@types/react": ">= 16.8.0 < 19.0.0", "react": ">= 16.8.0 < 19.0.0", "react-dom": ">= 16.8.0 < 19.0.0", "search-insights": ">= 1 < 3" }, "optionalPeers": ["@types/react", "react", "react-dom", "search-insights"] }, "sha512-xCRrJQlTt8N9GU0DG4ptwHRkfnSnD/YpdeaXe02iKfqs97TkZJv60yE+1eq/tjPcVnTW8dP5qLP7itifFVV5eg=="],
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw=="],
 
-    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.21.5", "", { "os": "aix", "cpu": "ppc64" }, "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ=="],
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.27.2", "", { "os": "android", "cpu": "arm" }, "sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA=="],
 
-    "@esbuild/android-arm": ["@esbuild/android-arm@0.21.5", "", { "os": "android", "cpu": "arm" }, "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg=="],
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.2", "", { "os": "android", "cpu": "arm64" }, "sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA=="],
 
-    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.21.5", "", { "os": "android", "cpu": "arm64" }, "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A=="],
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.27.2", "", { "os": "android", "cpu": "x64" }, "sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A=="],
 
-    "@esbuild/android-x64": ["@esbuild/android-x64@0.21.5", "", { "os": "android", "cpu": "x64" }, "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA=="],
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg=="],
 
-    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.21.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ=="],
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA=="],
 
-    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.21.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw=="],
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g=="],
 
-    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.21.5", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g=="],
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA=="],
 
-    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.21.5", "", { "os": "freebsd", "cpu": "x64" }, "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ=="],
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.2", "", { "os": "linux", "cpu": "arm" }, "sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw=="],
 
-    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.21.5", "", { "os": "linux", "cpu": "arm" }, "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA=="],
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw=="],
 
-    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.21.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q=="],
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.2", "", { "os": "linux", "cpu": "ia32" }, "sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w=="],
 
-    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.21.5", "", { "os": "linux", "cpu": "ia32" }, "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg=="],
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.2", "", { "os": "linux", "cpu": "none" }, "sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg=="],
 
-    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg=="],
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.2", "", { "os": "linux", "cpu": "none" }, "sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw=="],
 
-    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg=="],
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ=="],
 
-    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.21.5", "", { "os": "linux", "cpu": "ppc64" }, "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w=="],
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.2", "", { "os": "linux", "cpu": "none" }, "sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA=="],
 
-    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA=="],
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w=="],
 
-    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.21.5", "", { "os": "linux", "cpu": "s390x" }, "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A=="],
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.2", "", { "os": "linux", "cpu": "x64" }, "sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA=="],
 
-    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.21.5", "", { "os": "linux", "cpu": "x64" }, "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ=="],
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.2", "", { "os": "none", "cpu": "arm64" }, "sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw=="],
 
-    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.21.5", "", { "os": "none", "cpu": "x64" }, "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg=="],
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.2", "", { "os": "none", "cpu": "x64" }, "sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA=="],
 
-    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.21.5", "", { "os": "openbsd", "cpu": "x64" }, "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow=="],
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.2", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA=="],
 
-    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.21.5", "", { "os": "sunos", "cpu": "x64" }, "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg=="],
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.2", "", { "os": "openbsd", "cpu": "x64" }, "sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg=="],
 
-    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.21.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A=="],
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.2", "", { "os": "none", "cpu": "arm64" }, "sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag=="],
 
-    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.21.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA=="],
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.2", "", { "os": "sunos", "cpu": "x64" }, "sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg=="],
 
-    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.21.5", "", { "os": "win32", "cpu": "x64" }, "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw=="],
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.2", "", { "os": "win32", "cpu": "ia32" }, "sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.2", "", { "os": "win32", "cpu": "x64" }, "sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ=="],
 
     "@googleapis/drive": ["@googleapis/drive@20.0.0", "", { "dependencies": { "googleapis-common": "^8.0.0" } }, "sha512-qLi5ypZn0zYY2FcGjdlHQsv1DAFNRwCWFiE5kq23J0yTdUSZynh/mDph9NBaiQ9ybajrmttySR/rSaNfm8S/bA=="],
 
     "@hono/node-server": ["@hono/node-server@1.19.9", "", { "peerDependencies": { "hono": "^4" } }, "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw=="],
 
-    "@iconify-json/simple-icons": ["@iconify-json/simple-icons@1.2.48", "", { "dependencies": { "@iconify/types": "*" } }, "sha512-EACOtZMoPJtERiAbX1De0asrrCtlwI27+03c9OJlYWsly9w1O5vcD8rTzh+kDPjo+K8FOVnq2Qy+h/CzljSKDA=="],
+    "@iconify-json/simple-icons": ["@iconify-json/simple-icons@1.2.67", "", { "dependencies": { "@iconify/types": "*" } }, "sha512-RGJRwlxyup54L1UDAjCshy3ckX5zcvYIU74YLSnUgHGvqh6B4mvksbGNHAIEp7dZQ6cM13RZVT5KC07CmnFNew=="],
 
     "@iconify/types": ["@iconify/types@2.0.0", "", {}, "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg=="],
 
@@ -178,6 +143,8 @@
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
 
     "@publint/pack": ["@publint/pack@0.1.3", "", {}, "sha512-dHDWeutAerz+Z2wFYAce7Y51vd4rbLBfUh0BNnyul4xKoVsPUVJBrOAFsJvtvYBwGFJSqKsxyyHf/7evZ8+Q5Q=="],
+
+    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.53", "", {}, "sha512-vENRlFU4YbrwVqNDZ7fLvy+JR1CRkyr01jhSiDpE1u6py3OMzQfztQU2jxykW3ALNxO4kSlqIDeYyD0Y9RcQeQ=="],
 
     "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.46.2", "", { "os": "android", "cpu": "arm" }, "sha512-Zj3Hl6sN34xJtMv7Anwb5Gu01yujyE/cLBDB2gnHTAHaWS1Z38L7kuSG+oAh0giZMqG060f/YBStXtMH6FvPMA=="],
 
@@ -219,19 +186,19 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.46.2", "", { "os": "win32", "cpu": "x64" }, "sha512-CvUo2ixeIQGtF6WvuB87XWqPQkoFAFqW+HUo/WzHwuHDvIwZCtjdWXoYCcr06iKGydiqTclC4jU/TNObC/xKZg=="],
 
-    "@shikijs/core": ["@shikijs/core@2.5.0", "", { "dependencies": { "@shikijs/engine-javascript": "2.5.0", "@shikijs/engine-oniguruma": "2.5.0", "@shikijs/types": "2.5.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.4" } }, "sha512-uu/8RExTKtavlpH7XqnVYBrfBkUc20ngXiX9NSrBhOVZYv/7XQRKUyhtkeflY5QsxC0GbJThCerruZfsUaSldg=="],
+    "@shikijs/core": ["@shikijs/core@3.21.0", "", { "dependencies": { "@shikijs/types": "3.21.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-AXSQu/2n1UIQekY8euBJlvFYZIw0PHY63jUzGbrOma4wPxzznJXTXkri+QcHeBNaFxiiOljKxxJkVSoB3PjbyA=="],
 
-    "@shikijs/engine-javascript": ["@shikijs/engine-javascript@2.5.0", "", { "dependencies": { "@shikijs/types": "2.5.0", "@shikijs/vscode-textmate": "^10.0.2", "oniguruma-to-es": "^3.1.0" } }, "sha512-VjnOpnQf8WuCEZtNUdjjwGUbtAVKuZkVQ/5cHy/tojVVRIRtlWMYVjyWhxOmIq05AlSOv72z7hRNRGVBgQOl0w=="],
+    "@shikijs/engine-javascript": ["@shikijs/engine-javascript@3.21.0", "", { "dependencies": { "@shikijs/types": "3.21.0", "@shikijs/vscode-textmate": "^10.0.2", "oniguruma-to-es": "^4.3.4" } }, "sha512-ATwv86xlbmfD9n9gKRiwuPpWgPENAWCLwYCGz9ugTJlsO2kOzhOkvoyV/UD+tJ0uT7YRyD530x6ugNSffmvIiQ=="],
 
-    "@shikijs/engine-oniguruma": ["@shikijs/engine-oniguruma@2.5.0", "", { "dependencies": { "@shikijs/types": "2.5.0", "@shikijs/vscode-textmate": "^10.0.2" } }, "sha512-pGd1wRATzbo/uatrCIILlAdFVKdxImWJGQ5rFiB5VZi2ve5xj3Ax9jny8QvkaV93btQEwR/rSz5ERFpC5mKNIw=="],
+    "@shikijs/engine-oniguruma": ["@shikijs/engine-oniguruma@3.21.0", "", { "dependencies": { "@shikijs/types": "3.21.0", "@shikijs/vscode-textmate": "^10.0.2" } }, "sha512-OYknTCct6qiwpQDqDdf3iedRdzj6hFlOPv5hMvI+hkWfCKs5mlJ4TXziBG9nyabLwGulrUjHiCq3xCspSzErYQ=="],
 
-    "@shikijs/langs": ["@shikijs/langs@2.5.0", "", { "dependencies": { "@shikijs/types": "2.5.0" } }, "sha512-Qfrrt5OsNH5R+5tJ/3uYBBZv3SuGmnRPejV9IlIbFH3HTGLDlkqgHymAlzklVmKBjAaVmkPkyikAV/sQ1wSL+w=="],
+    "@shikijs/langs": ["@shikijs/langs@3.21.0", "", { "dependencies": { "@shikijs/types": "3.21.0" } }, "sha512-g6mn5m+Y6GBJ4wxmBYqalK9Sp0CFkUqfNzUy2pJglUginz6ZpWbaWjDB4fbQ/8SHzFjYbtU6Ddlp1pc+PPNDVA=="],
 
-    "@shikijs/themes": ["@shikijs/themes@2.5.0", "", { "dependencies": { "@shikijs/types": "2.5.0" } }, "sha512-wGrk+R8tJnO0VMzmUExHR+QdSaPUl/NKs+a4cQQRWyoc3YFbUzuLEi/KWK1hj+8BfHRKm2jNhhJck1dfstJpiw=="],
+    "@shikijs/themes": ["@shikijs/themes@3.21.0", "", { "dependencies": { "@shikijs/types": "3.21.0" } }, "sha512-BAE4cr9EDiZyYzwIHEk7JTBJ9CzlPuM4PchfcA5ao1dWXb25nv6hYsoDiBq2aZK9E3dlt3WB78uI96UESD+8Mw=="],
 
-    "@shikijs/transformers": ["@shikijs/transformers@2.5.0", "", { "dependencies": { "@shikijs/core": "2.5.0", "@shikijs/types": "2.5.0" } }, "sha512-SI494W5X60CaUwgi8u4q4m4s3YAFSxln3tzNjOSYqq54wlVgz0/NbbXEb3mdLbqMBztcmS7bVTaEd2w0qMmfeg=="],
+    "@shikijs/transformers": ["@shikijs/transformers@3.21.0", "", { "dependencies": { "@shikijs/core": "3.21.0", "@shikijs/types": "3.21.0" } }, "sha512-CZwvCWWIiRRiFk9/JKzdEooakAP8mQDtBOQ1TKiCaS2E1bYtyBCOkUzS8akO34/7ufICQ29oeSfkb3tT5KtrhA=="],
 
-    "@shikijs/types": ["@shikijs/types@2.5.0", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-ygl5yhxki9ZLNuNpPitBWvcy9fsSKKaRuO4BAlMyagszQidxcpLAr0qiW/q43DtSIDxO6hEbtYLiFZNXO/hdGw=="],
+    "@shikijs/types": ["@shikijs/types@3.21.0", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-zGrWOxZ0/+0ovPY7PvBU2gIS9tmhSUUt30jAcNV0Bq0gb2S98gwfjIs1vxlmH5zM7/4YxLamT6ChlqqAJmPPjA=="],
 
     "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
 
@@ -317,10 +284,6 @@
 
     "@types/node": ["@types/node@25.0.10", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-zWW5KPngR/yvakJgGOmZ5vTBemDoSqF3AcV/LrO5u5wTWyEAVVh+IT39G4gtyAkh3CtTZs8aX/yRM82OfzHJRg=="],
 
-    "@types/open": ["@types/open@6.2.1", "", { "dependencies": { "open": "*" } }, "sha512-CzV16LToFaKwm1FfplVTF08E3pznw4fQNCQ87N+A1RU00zu/se7npvb6IC9db3/emnSThQ6R8qFKgrei2M4EYQ=="],
-
-    "@types/react": ["@types/react@19.1.10", "", { "dependencies": { "csstype": "^3.0.2" } }, "sha512-EhBeSYX0Y6ye8pNebpKrwFJq7BoQ8J5SO6NlvNwwHjSj6adXJViPQrKlsyPw7hLBLvckEMO1yxeGdR82YBBlDg=="],
-
     "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
 
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
@@ -329,39 +292,39 @@
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
 
-    "@vitejs/plugin-vue": ["@vitejs/plugin-vue@5.2.4", "", { "peerDependencies": { "vite": "^5.0.0 || ^6.0.0", "vue": "^3.2.25" } }, "sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA=="],
+    "@vitejs/plugin-vue": ["@vitejs/plugin-vue@6.0.3", "", { "dependencies": { "@rolldown/pluginutils": "1.0.0-beta.53" }, "peerDependencies": { "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0", "vue": "^3.2.25" } }, "sha512-TlGPkLFLVOY3T7fZrwdvKpjprR3s4fxRln0ORDo1VQ7HHyxJwTlrjKU3kpVWTlaAjIEuCTokmjkZnr8Tpc925w=="],
 
-    "@vue/compiler-core": ["@vue/compiler-core@3.5.18", "", { "dependencies": { "@babel/parser": "^7.28.0", "@vue/shared": "3.5.18", "entities": "^4.5.0", "estree-walker": "^2.0.2", "source-map-js": "^1.2.1" } }, "sha512-3slwjQrrV1TO8MoXgy3aynDQ7lslj5UqDxuHnrzHtpON5CBinhWjJETciPngpin/T3OuW3tXUf86tEurusnztw=="],
+    "@vue/compiler-core": ["@vue/compiler-core@3.5.27", "", { "dependencies": { "@babel/parser": "^7.28.5", "@vue/shared": "3.5.27", "entities": "^7.0.0", "estree-walker": "^2.0.2", "source-map-js": "^1.2.1" } }, "sha512-gnSBQjZA+//qDZen+6a2EdHqJ68Z7uybrMf3SPjEGgG4dicklwDVmMC1AeIHxtLVPT7sn6sH1KOO+tS6gwOUeQ=="],
 
-    "@vue/compiler-dom": ["@vue/compiler-dom@3.5.18", "", { "dependencies": { "@vue/compiler-core": "3.5.18", "@vue/shared": "3.5.18" } }, "sha512-RMbU6NTU70++B1JyVJbNbeFkK+A+Q7y9XKE2EM4NLGm2WFR8x9MbAtWxPPLdm0wUkuZv9trpwfSlL6tjdIa1+A=="],
+    "@vue/compiler-dom": ["@vue/compiler-dom@3.5.27", "", { "dependencies": { "@vue/compiler-core": "3.5.27", "@vue/shared": "3.5.27" } }, "sha512-oAFea8dZgCtVVVTEC7fv3T5CbZW9BxpFzGGxC79xakTr6ooeEqmRuvQydIiDAkglZEAd09LgVf1RoDnL54fu5w=="],
 
-    "@vue/compiler-sfc": ["@vue/compiler-sfc@3.5.18", "", { "dependencies": { "@babel/parser": "^7.28.0", "@vue/compiler-core": "3.5.18", "@vue/compiler-dom": "3.5.18", "@vue/compiler-ssr": "3.5.18", "@vue/shared": "3.5.18", "estree-walker": "^2.0.2", "magic-string": "^0.30.17", "postcss": "^8.5.6", "source-map-js": "^1.2.1" } }, "sha512-5aBjvGqsWs+MoxswZPoTB9nSDb3dhd1x30xrrltKujlCxo48j8HGDNj3QPhF4VIS0VQDUrA1xUfp2hEa+FNyXA=="],
+    "@vue/compiler-sfc": ["@vue/compiler-sfc@3.5.27", "", { "dependencies": { "@babel/parser": "^7.28.5", "@vue/compiler-core": "3.5.27", "@vue/compiler-dom": "3.5.27", "@vue/compiler-ssr": "3.5.27", "@vue/shared": "3.5.27", "estree-walker": "^2.0.2", "magic-string": "^0.30.21", "postcss": "^8.5.6", "source-map-js": "^1.2.1" } }, "sha512-sHZu9QyDPeDmN/MRoshhggVOWE5WlGFStKFwu8G52swATgSny27hJRWteKDSUUzUH+wp+bmeNbhJnEAel/auUQ=="],
 
-    "@vue/compiler-ssr": ["@vue/compiler-ssr@3.5.18", "", { "dependencies": { "@vue/compiler-dom": "3.5.18", "@vue/shared": "3.5.18" } }, "sha512-xM16Ak7rSWHkM3m22NlmcdIM+K4BMyFARAfV9hYFl+SFuRzrZ3uGMNW05kA5pmeMa0X9X963Kgou7ufdbpOP9g=="],
+    "@vue/compiler-ssr": ["@vue/compiler-ssr@3.5.27", "", { "dependencies": { "@vue/compiler-dom": "3.5.27", "@vue/shared": "3.5.27" } }, "sha512-Sj7h+JHt512fV1cTxKlYhg7qxBvack+BGncSpH+8vnN+KN95iPIcqB5rsbblX40XorP+ilO7VIKlkuu3Xq2vjw=="],
 
-    "@vue/devtools-api": ["@vue/devtools-api@7.7.7", "", { "dependencies": { "@vue/devtools-kit": "^7.7.7" } }, "sha512-lwOnNBH2e7x1fIIbVT7yF5D+YWhqELm55/4ZKf45R9T8r9dE2AIOy8HKjfqzGsoTHFbWbr337O4E0A0QADnjBg=="],
+    "@vue/devtools-api": ["@vue/devtools-api@8.0.5", "", { "dependencies": { "@vue/devtools-kit": "^8.0.5" } }, "sha512-DgVcW8H/Nral7LgZEecYFFYXnAvGuN9C3L3DtWekAncFBedBczpNW8iHKExfaM559Zm8wQWrwtYZ9lXthEHtDw=="],
 
-    "@vue/devtools-kit": ["@vue/devtools-kit@7.7.7", "", { "dependencies": { "@vue/devtools-shared": "^7.7.7", "birpc": "^2.3.0", "hookable": "^5.5.3", "mitt": "^3.0.1", "perfect-debounce": "^1.0.0", "speakingurl": "^14.0.1", "superjson": "^2.2.2" } }, "sha512-wgoZtxcTta65cnZ1Q6MbAfePVFxfM+gq0saaeytoph7nEa7yMXoi6sCPy4ufO111B9msnw0VOWjPEFCXuAKRHA=="],
+    "@vue/devtools-kit": ["@vue/devtools-kit@8.0.5", "", { "dependencies": { "@vue/devtools-shared": "^8.0.5", "birpc": "^2.6.1", "hookable": "^5.5.3", "mitt": "^3.0.1", "perfect-debounce": "^2.0.0", "speakingurl": "^14.0.1", "superjson": "^2.2.2" } }, "sha512-q2VV6x1U3KJMTQPUlRMyWEKVbcHuxhqJdSr6Jtjz5uAThAIrfJ6WVZdGZm5cuO63ZnSUz0RCsVwiUUb0mDV0Yg=="],
 
-    "@vue/devtools-shared": ["@vue/devtools-shared@7.7.7", "", { "dependencies": { "rfdc": "^1.4.1" } }, "sha512-+udSj47aRl5aKb0memBvcUG9koarqnxNM5yjuREvqwK6T3ap4mn3Zqqc17QrBFTqSMjr3HK1cvStEZpMDpfdyw=="],
+    "@vue/devtools-shared": ["@vue/devtools-shared@8.0.5", "", { "dependencies": { "rfdc": "^1.4.1" } }, "sha512-bRLn6/spxpmgLk+iwOrR29KrYnJjG9DGpHGkDFG82UM21ZpJ39ztUT9OXX3g+usW7/b2z+h46I9ZiYyB07XMXg=="],
 
-    "@vue/reactivity": ["@vue/reactivity@3.5.18", "", { "dependencies": { "@vue/shared": "3.5.18" } }, "sha512-x0vPO5Imw+3sChLM5Y+B6G1zPjwdOri9e8V21NnTnlEvkxatHEH5B5KEAJcjuzQ7BsjGrKtfzuQ5eQwXh8HXBg=="],
+    "@vue/reactivity": ["@vue/reactivity@3.5.27", "", { "dependencies": { "@vue/shared": "3.5.27" } }, "sha512-vvorxn2KXfJ0nBEnj4GYshSgsyMNFnIQah/wczXlsNXt+ijhugmW+PpJ2cNPe4V6jpnBcs0MhCODKllWG+nvoQ=="],
 
-    "@vue/runtime-core": ["@vue/runtime-core@3.5.18", "", { "dependencies": { "@vue/reactivity": "3.5.18", "@vue/shared": "3.5.18" } }, "sha512-DUpHa1HpeOQEt6+3nheUfqVXRog2kivkXHUhoqJiKR33SO4x+a5uNOMkV487WPerQkL0vUuRvq/7JhRgLW3S+w=="],
+    "@vue/runtime-core": ["@vue/runtime-core@3.5.27", "", { "dependencies": { "@vue/reactivity": "3.5.27", "@vue/shared": "3.5.27" } }, "sha512-fxVuX/fzgzeMPn/CLQecWeDIFNt3gQVhxM0rW02Tvp/YmZfXQgcTXlakq7IMutuZ/+Ogbn+K0oct9J3JZfyk3A=="],
 
-    "@vue/runtime-dom": ["@vue/runtime-dom@3.5.18", "", { "dependencies": { "@vue/reactivity": "3.5.18", "@vue/runtime-core": "3.5.18", "@vue/shared": "3.5.18", "csstype": "^3.1.3" } }, "sha512-YwDj71iV05j4RnzZnZtGaXwPoUWeRsqinblgVJwR8XTXYZ9D5PbahHQgsbmzUvCWNF6x7siQ89HgnX5eWkr3mw=="],
+    "@vue/runtime-dom": ["@vue/runtime-dom@3.5.27", "", { "dependencies": { "@vue/reactivity": "3.5.27", "@vue/runtime-core": "3.5.27", "@vue/shared": "3.5.27", "csstype": "^3.2.3" } }, "sha512-/QnLslQgYqSJ5aUmb5F0z0caZPGHRB8LEAQ1s81vHFM5CBfnun63rxhvE/scVb/j3TbBuoZwkJyiLCkBluMpeg=="],
 
-    "@vue/server-renderer": ["@vue/server-renderer@3.5.18", "", { "dependencies": { "@vue/compiler-ssr": "3.5.18", "@vue/shared": "3.5.18" }, "peerDependencies": { "vue": "3.5.18" } }, "sha512-PvIHLUoWgSbDG7zLHqSqaCoZvHi6NNmfVFOqO+OnwvqMz/tqQr3FuGWS8ufluNddk7ZLBJYMrjcw1c6XzR12mA=="],
+    "@vue/server-renderer": ["@vue/server-renderer@3.5.27", "", { "dependencies": { "@vue/compiler-ssr": "3.5.27", "@vue/shared": "3.5.27" }, "peerDependencies": { "vue": "3.5.27" } }, "sha512-qOz/5thjeP1vAFc4+BY3Nr6wxyLhpeQgAE/8dDtKo6a6xdk+L4W46HDZgNmLOBUDEkFXV3G7pRiUqxjX0/2zWA=="],
 
-    "@vue/shared": ["@vue/shared@3.5.18", "", {}, "sha512-cZy8Dq+uuIXbxCZpuLd2GJdeSO/lIzIspC2WtkqIpje5QyFbvLaI5wZtdUjLHjGZrlVX6GilejatWwVYYRc8tA=="],
+    "@vue/shared": ["@vue/shared@3.5.27", "", {}, "sha512-dXr/3CgqXsJkZ0n9F3I4elY8wM9jMJpP3pvRG52r6m0tu/MsAFIe6JpXVGeNMd/D9F4hQynWT8Rfuj0bdm9kFQ=="],
 
-    "@vueuse/core": ["@vueuse/core@12.8.2", "", { "dependencies": { "@types/web-bluetooth": "^0.0.21", "@vueuse/metadata": "12.8.2", "@vueuse/shared": "12.8.2", "vue": "^3.5.13" } }, "sha512-HbvCmZdzAu3VGi/pWYm5Ut+Kd9mn1ZHnn4L5G8kOQTPs/IwIAmJoBrmYk2ckLArgMXZj0AW3n5CAejLUO+PhdQ=="],
+    "@vueuse/core": ["@vueuse/core@14.1.0", "", { "dependencies": { "@types/web-bluetooth": "^0.0.21", "@vueuse/metadata": "14.1.0", "@vueuse/shared": "14.1.0" }, "peerDependencies": { "vue": "^3.5.0" } }, "sha512-rgBinKs07hAYyPF834mDTigH7BtPqvZ3Pryuzt1SD/lg5wEcWqvwzXXYGEDb2/cP0Sj5zSvHl3WkmMELr5kfWw=="],
 
-    "@vueuse/integrations": ["@vueuse/integrations@12.8.2", "", { "dependencies": { "@vueuse/core": "12.8.2", "@vueuse/shared": "12.8.2", "vue": "^3.5.13" }, "peerDependencies": { "async-validator": "^4", "axios": "^1", "change-case": "^5", "drauu": "^0.4", "focus-trap": "^7", "fuse.js": "^7", "idb-keyval": "^6", "jwt-decode": "^4", "nprogress": "^0.2", "qrcode": "^1.5", "sortablejs": "^1", "universal-cookie": "^7" }, "optionalPeers": ["async-validator", "axios", "change-case", "drauu", "focus-trap", "fuse.js", "idb-keyval", "jwt-decode", "nprogress", "qrcode", "sortablejs", "universal-cookie"] }, "sha512-fbGYivgK5uBTRt7p5F3zy6VrETlV9RtZjBqd1/HxGdjdckBgBM4ugP8LHpjolqTj14TXTxSK1ZfgPbHYyGuH7g=="],
+    "@vueuse/integrations": ["@vueuse/integrations@14.1.0", "", { "dependencies": { "@vueuse/core": "14.1.0", "@vueuse/shared": "14.1.0" }, "peerDependencies": { "async-validator": "^4", "axios": "^1", "change-case": "^5", "drauu": "^0.4", "focus-trap": "^7", "fuse.js": "^7", "idb-keyval": "^6", "jwt-decode": "^4", "nprogress": "^0.2", "qrcode": "^1.5", "sortablejs": "^1", "universal-cookie": "^7 || ^8", "vue": "^3.5.0" }, "optionalPeers": ["async-validator", "axios", "change-case", "drauu", "focus-trap", "fuse.js", "idb-keyval", "jwt-decode", "nprogress", "qrcode", "sortablejs", "universal-cookie"] }, "sha512-eNQPdisnO9SvdydTIXnTE7c29yOsJBD/xkwEyQLdhDC/LKbqrFpXHb3uS//7NcIrQO3fWVuvMGp8dbK6mNEMCA=="],
 
-    "@vueuse/metadata": ["@vueuse/metadata@12.8.2", "", {}, "sha512-rAyLGEuoBJ/Il5AmFHiziCPdQzRt88VxR+Y/A/QhJ1EWtWqPBBAxTAFaSkviwEuOEZNtW8pvkPgoCZQ+HxqW1A=="],
+    "@vueuse/metadata": ["@vueuse/metadata@14.1.0", "", {}, "sha512-7hK4g015rWn2PhKcZ99NyT+ZD9sbwm7SGvp7k+k+rKGWnLjS/oQozoIZzWfCewSUeBmnJkIb+CNr7Zc/EyRnnA=="],
 
-    "@vueuse/shared": ["@vueuse/shared@12.8.2", "", { "dependencies": { "vue": "^3.5.13" } }, "sha512-dznP38YzxZoNloI0qpEfpkms8knDtaoQ6Y/sfS0L7Yki4zh40LFHEhur0odJC6xTHG5dxWVPiUWBXn+wCG2s5w=="],
+    "@vueuse/shared": ["@vueuse/shared@14.1.0", "", { "peerDependencies": { "vue": "^3.5.0" } }, "sha512-EcKxtYvn6gx1F8z9J5/rsg3+lTQnvOruQd8fUecW99DCK04BkWD7z5KQ/wTAx+DazyoEE9dJt/zV8OIEQbM6kw=="],
 
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 
@@ -372,8 +335,6 @@
     "ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
 
     "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
-
-    "algoliasearch": ["algoliasearch@5.35.0", "", { "dependencies": { "@algolia/abtesting": "1.1.0", "@algolia/client-abtesting": "5.35.0", "@algolia/client-analytics": "5.35.0", "@algolia/client-common": "5.35.0", "@algolia/client-insights": "5.35.0", "@algolia/client-personalization": "5.35.0", "@algolia/client-query-suggestions": "5.35.0", "@algolia/client-search": "5.35.0", "@algolia/ingestion": "1.35.0", "@algolia/monitoring": "1.35.0", "@algolia/recommend": "5.35.0", "@algolia/requester-browser-xhr": "5.35.0", "@algolia/requester-fetch": "5.35.0", "@algolia/requester-node-http": "5.35.0" } }, "sha512-Y+moNhsqgLmvJdgTsO4GZNgsaDWv8AOGAaPeIeHKlDn/XunoAqYbA+XNpBd1dW8GOXAUDyxC9Rxc7AV4kpFcIg=="],
 
     "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
@@ -387,7 +348,7 @@
 
     "bignumber.js": ["bignumber.js@9.3.1", "", {}, "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ=="],
 
-    "birpc": ["birpc@2.5.0", "", {}, "sha512-VSWO/W6nNQdyP520F1mhf+Lc2f8pjGQOtoHHm7Ze8Go1kX7akpVIrtTa0fn+HB0QJEDVacl6aO08YE0PgXfdnQ=="],
+    "birpc": ["birpc@2.9.0", "", {}, "sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw=="],
 
     "body-parser": ["body-parser@2.2.0", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.0", "http-errors": "^2.0.0", "iconv-lite": "^0.6.3", "on-finished": "^2.4.1", "qs": "^6.14.0", "raw-body": "^3.0.0", "type-is": "^2.0.0" } }, "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg=="],
 
@@ -453,7 +414,7 @@
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
-    "csstype": ["csstype@3.1.3", "", {}, "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="],
+    "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
     "cytoscape": ["cytoscape@3.33.1", "", {}, "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ=="],
 
@@ -559,11 +520,9 @@
 
     "emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 
-    "emoji-regex-xs": ["emoji-regex-xs@1.0.0", "", {}, "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg=="],
-
     "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
 
-    "entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+    "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
     "env-paths": ["env-paths@2.2.1", "", {}, "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="],
 
@@ -575,7 +534,7 @@
 
     "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
 
-    "esbuild": ["esbuild@0.21.5", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.21.5", "@esbuild/android-arm": "0.21.5", "@esbuild/android-arm64": "0.21.5", "@esbuild/android-x64": "0.21.5", "@esbuild/darwin-arm64": "0.21.5", "@esbuild/darwin-x64": "0.21.5", "@esbuild/freebsd-arm64": "0.21.5", "@esbuild/freebsd-x64": "0.21.5", "@esbuild/linux-arm": "0.21.5", "@esbuild/linux-arm64": "0.21.5", "@esbuild/linux-ia32": "0.21.5", "@esbuild/linux-loong64": "0.21.5", "@esbuild/linux-mips64el": "0.21.5", "@esbuild/linux-ppc64": "0.21.5", "@esbuild/linux-riscv64": "0.21.5", "@esbuild/linux-s390x": "0.21.5", "@esbuild/linux-x64": "0.21.5", "@esbuild/netbsd-x64": "0.21.5", "@esbuild/openbsd-x64": "0.21.5", "@esbuild/sunos-x64": "0.21.5", "@esbuild/win32-arm64": "0.21.5", "@esbuild/win32-ia32": "0.21.5", "@esbuild/win32-x64": "0.21.5" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw=="],
+    "esbuild": ["esbuild@0.27.2", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.2", "@esbuild/android-arm": "0.27.2", "@esbuild/android-arm64": "0.27.2", "@esbuild/android-x64": "0.27.2", "@esbuild/darwin-arm64": "0.27.2", "@esbuild/darwin-x64": "0.27.2", "@esbuild/freebsd-arm64": "0.27.2", "@esbuild/freebsd-x64": "0.27.2", "@esbuild/linux-arm": "0.27.2", "@esbuild/linux-arm64": "0.27.2", "@esbuild/linux-ia32": "0.27.2", "@esbuild/linux-loong64": "0.27.2", "@esbuild/linux-mips64el": "0.27.2", "@esbuild/linux-ppc64": "0.27.2", "@esbuild/linux-riscv64": "0.27.2", "@esbuild/linux-s390x": "0.27.2", "@esbuild/linux-x64": "0.27.2", "@esbuild/netbsd-arm64": "0.27.2", "@esbuild/netbsd-x64": "0.27.2", "@esbuild/openbsd-arm64": "0.27.2", "@esbuild/openbsd-x64": "0.27.2", "@esbuild/openharmony-arm64": "0.27.2", "@esbuild/sunos-x64": "0.27.2", "@esbuild/win32-arm64": "0.27.2", "@esbuild/win32-ia32": "0.27.2", "@esbuild/win32-x64": "0.27.2" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw=="],
 
     "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
 
@@ -601,13 +560,15 @@
 
     "fastq": ["fastq@1.20.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw=="],
 
+    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
     "fetch-blob": ["fetch-blob@3.2.0", "", { "dependencies": { "node-domexception": "^1.0.0", "web-streams-polyfill": "^3.0.3" } }, "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ=="],
 
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
 
     "finalhandler": ["finalhandler@2.1.0", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q=="],
 
-    "focus-trap": ["focus-trap@7.6.5", "", { "dependencies": { "tabbable": "^6.2.0" } }, "sha512-7Ke1jyybbbPZyZXFxEftUtxFGLMpE2n6A+z//m4CRDlj0hW+o3iYSmh8nFlYMurOiJVDmJRilUQtJr08KfIxlg=="],
+    "focus-trap": ["focus-trap@7.8.0", "", { "dependencies": { "tabbable": "^6.4.0" } }, "sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA=="],
 
     "foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
 
@@ -741,7 +702,7 @@
 
     "lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
-    "magic-string": ["magic-string@0.30.17", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0" } }, "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA=="],
+    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
     "mark.js": ["mark.js@8.11.1", "", {}, "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ=="],
 
@@ -781,7 +742,7 @@
 
     "minipass": ["minipass@7.1.2", "", {}, "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="],
 
-    "minisearch": ["minisearch@7.1.2", "", {}, "sha512-R1Pd9eF+MD5JYDDSPAp/q1ougKglm14uEkPMvQ/05RGmx6G9wvmLTrTI/Q5iPNJLYqNdsDQ7qTGIcNWR+FrHmA=="],
+    "minisearch": ["minisearch@7.2.0", "", {}, "sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg=="],
 
     "mitt": ["mitt@3.0.1", "", {}, "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw=="],
 
@@ -813,7 +774,9 @@
 
     "onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
 
-    "oniguruma-to-es": ["oniguruma-to-es@3.1.1", "", { "dependencies": { "emoji-regex-xs": "^1.0.0", "regex": "^6.0.1", "regex-recursion": "^6.0.2" } }, "sha512-bUH8SDvPkH3ho3dvwJwfonjlQ4R80vjyvrU8YpxuROddv55vAEJrTuCuCVUhhsHbtlD9tGGbaNApGQckXhS8iQ=="],
+    "oniguruma-parser": ["oniguruma-parser@0.12.1", "", {}, "sha512-8Unqkvk1RYc6yq2WBYRj4hdnsAxVze8i7iPfQr8e4uSP3tRv0rpZcbGUDvxfQQcdwHt/e9PrMvGCsa8OqG9X3w=="],
+
+    "oniguruma-to-es": ["oniguruma-to-es@4.3.4", "", { "dependencies": { "oniguruma-parser": "^0.12.1", "regex": "^6.0.1", "regex-recursion": "^6.0.2" } }, "sha512-3VhUGN3w2eYxnTzHn+ikMI+fp/96KoRSVK9/kMTcFqj1NRDh2IhQCKvYxDnWePKRXY/AqH+Fuiyb7VHSzBjHfA=="],
 
     "open": ["open@11.0.0", "", { "dependencies": { "default-browser": "^5.4.0", "define-lazy-prop": "^3.0.0", "is-in-ssh": "^1.0.0", "is-inside-container": "^1.0.0", "powershell-utils": "^0.1.0", "wsl-utils": "^0.3.0" } }, "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw=="],
 
@@ -839,7 +802,7 @@
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
-    "perfect-debounce": ["perfect-debounce@1.0.0", "", {}, "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA=="],
+    "perfect-debounce": ["perfect-debounce@2.1.0", "", {}, "sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
@@ -856,8 +819,6 @@
     "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
 
     "powershell-utils": ["powershell-utils@0.1.0", "", {}, "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A=="],
-
-    "preact": ["preact@10.27.0", "", {}, "sha512-/DTYoB6mwwgPytiqQTh/7SFRL98ZdiD8Sk8zIUVOxtwq4oWcwrcd1uno9fE/zZmUaUrFNYzbH14CPebOz9tZQw=="],
 
     "prettier": ["prettier@3.8.1", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg=="],
 
@@ -913,8 +874,6 @@
 
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
-    "search-insights": ["search-insights@2.17.3", "", {}, "sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ=="],
-
     "send": ["send@1.2.0", "", { "dependencies": { "debug": "^4.3.5", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.0", "mime-types": "^3.0.1", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.1" } }, "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw=="],
 
     "serve-static": ["serve-static@2.2.0", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ=="],
@@ -925,7 +884,7 @@
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
 
-    "shiki": ["shiki@2.5.0", "", { "dependencies": { "@shikijs/core": "2.5.0", "@shikijs/engine-javascript": "2.5.0", "@shikijs/engine-oniguruma": "2.5.0", "@shikijs/langs": "2.5.0", "@shikijs/themes": "2.5.0", "@shikijs/types": "2.5.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-mI//trrsaiCIPsja5CNfsyNOqgAZUb6VpJA+340toL42UpzQlXpwRV9nch69X6gaUxrr9kaOOa6e3y3uAkGFxQ=="],
+    "shiki": ["shiki@3.21.0", "", { "dependencies": { "@shikijs/core": "3.21.0", "@shikijs/engine-javascript": "3.21.0", "@shikijs/engine-oniguruma": "3.21.0", "@shikijs/langs": "3.21.0", "@shikijs/themes": "3.21.0", "@shikijs/types": "3.21.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-N65B/3bqL/TI2crrXr+4UivctrAGEjmsib5rPMMPpFp1xAx/w03v8WZ9RDDFYteXoEgY7qZ4HGgl5KBIu1153w=="],
 
     "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
 
@@ -965,9 +924,11 @@
 
     "superjson": ["superjson@2.2.2", "", { "dependencies": { "copy-anything": "^3.0.2" } }, "sha512-5JRxVqC8I8NuOUjzBbvVJAKNM8qoVuH0O77h4WInc/qC2q5IreqKxYwgkga3PfA22OayK2ikceb/B26dztPl+Q=="],
 
-    "tabbable": ["tabbable@6.2.0", "", {}, "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew=="],
+    "tabbable": ["tabbable@6.4.0", "", {}, "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg=="],
 
     "tinyexec": ["tinyexec@1.0.1", "", {}, "sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw=="],
+
+    "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
@@ -1007,9 +968,9 @@
 
     "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
 
-    "vite": ["vite@5.4.19", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA=="],
+    "vite": ["vite@7.3.1", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA=="],
 
-    "vitepress": ["vitepress@1.6.4", "", { "dependencies": { "@docsearch/css": "3.8.2", "@docsearch/js": "3.8.2", "@iconify-json/simple-icons": "^1.2.21", "@shikijs/core": "^2.1.0", "@shikijs/transformers": "^2.1.0", "@shikijs/types": "^2.1.0", "@types/markdown-it": "^14.1.2", "@vitejs/plugin-vue": "^5.2.1", "@vue/devtools-api": "^7.7.0", "@vue/shared": "^3.5.13", "@vueuse/core": "^12.4.0", "@vueuse/integrations": "^12.4.0", "focus-trap": "^7.6.4", "mark.js": "8.11.1", "minisearch": "^7.1.1", "shiki": "^2.1.0", "vite": "^5.4.14", "vue": "^3.5.13" }, "peerDependencies": { "markdown-it-mathjax3": "^4", "postcss": "^8" }, "optionalPeers": ["markdown-it-mathjax3", "postcss"], "bin": { "vitepress": "bin/vitepress.js" } }, "sha512-+2ym1/+0VVrbhNyRoFFesVvBvHAVMZMK0rw60E3X/5349M1GuVdKeazuksqopEdvkKwKGs21Q729jX81/bkBJg=="],
+    "vitepress": ["vitepress@2.0.0-alpha.15", "", { "dependencies": { "@docsearch/css": "^4.3.2", "@docsearch/js": "^4.3.2", "@iconify-json/simple-icons": "^1.2.59", "@shikijs/core": "^3.15.0", "@shikijs/transformers": "^3.15.0", "@shikijs/types": "^3.15.0", "@types/markdown-it": "^14.1.2", "@vitejs/plugin-vue": "^6.0.1", "@vue/devtools-api": "^8.0.5", "@vue/shared": "^3.5.24", "@vueuse/core": "^14.0.0", "@vueuse/integrations": "^14.0.0", "focus-trap": "^7.6.6", "mark.js": "8.11.1", "minisearch": "^7.2.0", "shiki": "^3.15.0", "vite": "^7.2.2", "vue": "^3.5.24" }, "peerDependencies": { "markdown-it-mathjax3": "^4", "oxc-minify": "*", "postcss": "^8" }, "optionalPeers": ["markdown-it-mathjax3", "oxc-minify", "postcss"], "bin": { "vitepress": "bin/vitepress.js" } }, "sha512-jhjSYd10Z6RZiKOa7jy0xMVf5NB5oSc/lS3bD/QoUc6V8PrvQR5JhC9104NEt6+oTGY/ftieVWxY9v7YI+1IjA=="],
 
     "vitepress-plugin-mermaid": ["vitepress-plugin-mermaid@2.0.17", "", { "optionalDependencies": { "@mermaid-js/mermaid-mindmap": "^9.3.0" }, "peerDependencies": { "mermaid": "10 || 11", "vitepress": "^1.0.0 || ^1.0.0-alpha" } }, "sha512-IUzYpwf61GC6k0XzfmAmNrLvMi9TRrVRMsUyCA8KNXhg/mQ1VqWnO0/tBVPiX5UoKF1mDUwqn5QV4qAJl6JnUg=="],
 
@@ -1025,7 +986,7 @@
 
     "vscode-uri": ["vscode-uri@3.0.8", "", {}, "sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw=="],
 
-    "vue": ["vue@3.5.18", "", { "dependencies": { "@vue/compiler-dom": "3.5.18", "@vue/compiler-sfc": "3.5.18", "@vue/runtime-dom": "3.5.18", "@vue/server-renderer": "3.5.18", "@vue/shared": "3.5.18" }, "peerDependencies": { "typescript": "*" }, "optionalPeers": ["typescript"] }, "sha512-7W4Y4ZbMiQ3SEo+m9lnoNpV9xG7QVMLa+/0RFwwiAVkeYoyGXqWE85jabU4pllJNUzqfLShJ5YLptewhCWUgNA=="],
+    "vue": ["vue@3.5.27", "", { "dependencies": { "@vue/compiler-dom": "3.5.27", "@vue/compiler-sfc": "3.5.27", "@vue/runtime-dom": "3.5.27", "@vue/server-renderer": "3.5.27", "@vue/shared": "3.5.27" }, "peerDependencies": { "typescript": "*" }, "optionalPeers": ["typescript"] }, "sha512-aJ/UtoEyFySPBGarREmN4z6qNKpbEguYHMmXSiOGk69czc+zhs0NF6tEFrY8TZKAl8N/LYAkd4JHVd5E/AsSmw=="],
 
     "web-streams-polyfill": ["web-streams-polyfill@3.3.3", "", {}, "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="],
 
@@ -1049,13 +1010,9 @@
 
     "@antfu/install-pkg/package-manager-detector": ["package-manager-detector@1.3.0", "", {}, "sha512-ZsEbbZORsyHuO00lY1kV3/t72yp6Ysay6Pd17ZAlNGuGwmWDLCJxFpRs0IzfXfj1o4icJOkUEioexFHzyPurSQ=="],
 
-    "@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.27.1", "", {}, "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow=="],
-
     "@isaacs/cliui/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
 
     "@mermaid-js/mermaid-mindmap/@braintree/sanitize-url": ["@braintree/sanitize-url@6.0.4", "", {}, "sha512-s3jaWicZd0pkP0jf5ysyHUI/RE7MHos6qlToFcGWXVp+ykHOy77OUMrfbgJ9it2C5bow7OIQwYYaHjk9XlBQ2A=="],
-
-    "@types/open/open": ["open@10.2.0", "", { "dependencies": { "default-browser": "^5.2.1", "define-lazy-prop": "^3.0.0", "is-inside-container": "^1.0.0", "wsl-utils": "^0.1.0" } }, "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA=="],
 
     "bun-types/@types/node": ["@types/node@24.10.9", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-ne4A0IpG3+2ETuREInjPNhUGis1SFjv1d5asp8MzEAGtOZeTeHVDOYqOgqfhvseqg/iXty2hjBf1zAOb7RNiNw=="],
 
@@ -1088,10 +1045,6 @@
     "wrap-ansi-cjs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "wrap-ansi-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
-
-    "@types/open/open/default-browser": ["default-browser@5.2.1", "", { "dependencies": { "bundle-name": "^4.1.0", "default-browser-id": "^5.0.0" } }, "sha512-WY/3TUME0x3KPYdRRxEJJvXRHV4PyPoUsxtZa78lwItwRQRHhd2U9xOscaT/YTf8uCXIAjeJOFBVEh/7FtD8Xg=="],
-
-    "@types/open/open/wsl-utils": ["wsl-utils@0.1.0", "", { "dependencies": { "is-wsl": "^3.1.0" } }, "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw=="],
 
     "cytoscape-fcose/cose-base/layout-base": ["layout-base@2.0.1", "", {}, "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg=="],
 

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,82 +1,104 @@
 /* SPDX-FileCopyrightText: 2025-present Kriasoft */
 /* SPDX-License-Identifier: MIT */
 
+import { defineConfig } from "vitepress";
 import { withMermaid } from "vitepress-plugin-mermaid";
 
-// https://vitepress.dev/reference/site-config
-export default withMermaid({
-  base: "/oauth-callback/",
-  title: "🔐 \u00A0OAuth Callback",
-  description:
-    "OAuth 2.0 callback handler for CLI tools & desktop apps. Cross-runtime (Node.js/Deno/Bun), MCP SDK integration, minimal deps, TypeScript-first.",
-  themeConfig: {
-    // https://vitepress.dev/reference/default-theme-config
-    nav: [
-      { text: "Guide", link: "/getting-started" },
-      { text: "API", link: "/api/get-auth-code" },
-      { text: "Examples", link: "/examples/notion" },
-      {
-        text: "v1.2.0",
-        items: [
-          {
-            text: "Release Notes",
-            link: "https://github.com/kriasoft/oauth-callback/releases",
-          },
-          {
-            text: "npm",
-            link: "https://www.npmjs.com/package/oauth-callback",
-          },
-        ],
-      },
-    ],
+export default withMermaid(
+  defineConfig({
+    base: "/oauth-callback/",
+    title: "OAuth Callback",
+    description:
+      "OAuth 2.0 callback handler for CLI tools & desktop apps. Cross-runtime (Node.js/Deno/Bun), MCP SDK integration, minimal deps, TypeScript-first.",
 
-    sidebar: [
-      {
-        text: "Introduction",
-        items: [
-          { text: "What is OAuth Callback?", link: "/what-is-oauth-callback" },
-          { text: "Getting Started", link: "/getting-started" },
-          { text: "Core Concepts", link: "/core-concepts" },
-        ],
-      },
-      {
-        text: "API Reference",
-        items: [
-          { text: "getAuthCode", link: "/api/get-auth-code" },
-          { text: "browserAuth", link: "/api/browser-auth" },
-          { text: "Storage Providers", link: "/api/storage-providers" },
-          { text: "OAuthError", link: "/api/oauth-error" },
-          { text: "TypeScript Types", link: "/api/types" },
-        ],
-      },
-      {
-        text: "Examples",
-        items: [
-          { text: "Notion MCP", link: "/examples/notion" },
-          { text: "Linear MCP", link: "/examples/linear" },
-        ],
-      },
-    ],
+    lastUpdated: true,
+    cleanUrls: true,
+    metaChunk: true,
 
-    search: {
-      provider: "local",
+    sitemap: {
+      hostname: "https://kriasoft.com/oauth-callback",
     },
 
-    editLink: {
-      pattern:
-        "https://github.com/kriasoft/oauth-callback/edit/main/docs/:path",
-      text: "Edit this page on GitHub",
-    },
-
-    socialLinks: [
-      { icon: "github", link: "https://github.com/kriasoft/oauth-callback" },
-      { icon: "npm", link: "https://www.npmjs.com/package/oauth-callback" },
-      { icon: "discord", link: "https://discord.gg/bSsv7XM" },
+    head: [
+      ["meta", { name: "theme-color", content: "#3c8772" }],
+      ["meta", { property: "og:type", content: "website" }],
+      ["meta", { property: "og:site_name", content: "OAuth Callback" }],
+      [
+        "meta",
+        { property: "og:url", content: "https://kriasoft.com/oauth-callback/" },
+      ],
     ],
 
-    footer: {
-      message: "Released under the MIT License.",
-      copyright: "Copyright © 2025-present Konstantin Tarkus",
+    themeConfig: {
+      nav: [
+        { text: "Guide", link: "/getting-started" },
+        { text: "API", link: "/api/get-auth-code" },
+        { text: "Examples", link: "/examples/notion" },
+        {
+          text: "v2.0.0",
+          items: [
+            {
+              text: "Release Notes",
+              link: "https://github.com/kriasoft/oauth-callback/releases",
+            },
+            {
+              text: "npm",
+              link: "https://www.npmjs.com/package/oauth-callback",
+            },
+          ],
+        },
+      ],
+
+      sidebar: [
+        {
+          text: "Introduction",
+          items: [
+            {
+              text: "What is OAuth Callback?",
+              link: "/what-is-oauth-callback",
+            },
+            { text: "Getting Started", link: "/getting-started" },
+            { text: "Core Concepts", link: "/core-concepts" },
+          ],
+        },
+        {
+          text: "API Reference",
+          items: [
+            { text: "getAuthCode", link: "/api/get-auth-code" },
+            { text: "browserAuth", link: "/api/browser-auth" },
+            { text: "Storage Providers", link: "/api/storage-providers" },
+            { text: "OAuthError", link: "/api/oauth-error" },
+            { text: "TypeScript Types", link: "/api/types" },
+          ],
+        },
+        {
+          text: "Examples",
+          items: [
+            { text: "Notion MCP", link: "/examples/notion" },
+            { text: "Linear MCP", link: "/examples/linear" },
+          ],
+        },
+      ],
+
+      search: {
+        provider: "local",
+      },
+
+      editLink: {
+        pattern:
+          "https://github.com/kriasoft/oauth-callback/edit/main/docs/:path",
+      },
+
+      socialLinks: [
+        { icon: "github", link: "https://github.com/kriasoft/oauth-callback" },
+        { icon: "npm", link: "https://www.npmjs.com/package/oauth-callback" },
+        { icon: "discord", link: "https://discord.gg/bSsv7XM" },
+      ],
+
+      footer: {
+        message: "Released under the MIT License.",
+        copyright: "Copyright © 2025-present Kriasoft",
+      },
     },
-  },
-});
+  }),
+);

--- a/docs/api/browser-auth.md
+++ b/docs/api/browser-auth.md
@@ -26,10 +26,9 @@ function browserAuth(options?: BrowserAuthOptions): OAuthClientProvider;
 | `hostname`     | `string`                 | `"localhost"`     | Hostname to bind server to         |
 | `callbackPath` | `string`                 | `"/callback"`     | URL path for OAuth callback        |
 | `store`        | `TokenStore`             | `inMemoryStore()` | Token storage implementation       |
-| `storeKey`     | `string`                 | `"mcp-tokens"`    | Storage key prefix                 |
-| `openBrowser`  | `boolean \| string`      | `true`            | Auto-open browser                  |
+| `storeKey`     | `string`                 | `"mcp-tokens"`    | Storage key for token isolation    |
+| `launch`       | `(url: string) => unknown` | _none_          | Callback to launch auth URL        |
 | `authTimeout`  | `number`                 | `300000`          | Auth timeout in ms (5 min)         |
-| `usePKCE`      | `boolean`                | `true`            | Enable PKCE for security           |
 | `successHtml`  | `string`                 | _built-in_        | Custom success page HTML           |
 | `errorHtml`    | `string`                 | _built-in_        | Custom error page HTML             |
 | `onRequest`    | `(req: Request) => void` | _none_            | Request logging callback           |
@@ -70,12 +69,13 @@ interface OAuthClientProvider {
 The simplest usage with default settings:
 
 ```typescript
+import open from "open";
 import { browserAuth } from "oauth-callback/mcp";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 
-// Create OAuth provider with defaults
-const authProvider = browserAuth();
+// Create OAuth provider - pass open to launch browser
+const authProvider = browserAuth({ launch: open });
 
 // Use with MCP transport
 const transport = new StreamableHTTPClientTransport(
@@ -223,11 +223,11 @@ const authProvider = browserAuth({
 
 ### Headless/CI Environment
 
-Disable browser auto-opening for automated environments:
+Disable browser opening for automated environments:
 
 ```typescript
 const authProvider = browserAuth({
-  openBrowser: false,
+  launch: () => {}, // Noop - no browser opening
   authTimeout: 10000, // Shorter timeout for CI
   store: inMemoryStore(),
 });
@@ -396,13 +396,7 @@ const authProvider = browserAuth({
 
 ### PKCE (Proof Key for Code Exchange)
 
-PKCE is enabled by default for enhanced security:
-
-```typescript
-const authProvider = browserAuth({
-  usePKCE: true, // Default: true
-});
-```
+PKCE is always enabled for enhanced security. The MCP SDK handles PKCE automatically through the provider's `saveCodeVerifier()` and `codeVerifier()` methods.
 
 PKCE prevents authorization code interception attacks by:
 
@@ -685,7 +679,7 @@ describe("OAuth Flow Integration", () => {
   it("should complete full OAuth flow", async () => {
     const authProvider = browserAuth({
       port: 3001,
-      openBrowser: false, // Don't open browser in tests
+      launch: () => {}, // Noop - don't open browser in tests
       store: inMemoryStore(),
     });
 
@@ -743,9 +737,11 @@ const authProvider = browserAuth({
 ::: details Browser Not Opening
 
 ```typescript
-// Check if running in headless environment
+import open from "open";
+
+// Conditionally open browser based on environment
 const authProvider = browserAuth({
-  openBrowser: process.env.CI !== "true",
+  launch: process.env.CI ? () => {} : open,
 });
 ```
 
@@ -781,6 +777,7 @@ const tokens = await exchangeCodeForTokens(code);
 
 // After: Using browserAuth
 const authProvider = browserAuth({
+  launch: open,
   store: fileStore(),
 });
 // Automatic handling of entire OAuth flow!
@@ -790,10 +787,11 @@ const authProvider = browserAuth({
 
 ```typescript
 // Before: Tokens lost on restart
-const authProvider = browserAuth();
+const authProvider = browserAuth({ launch: open });
 
 // After: Tokens persist across sessions
 const authProvider = browserAuth({
+  launch: open,
   store: fileStore(),
 });
 ```

--- a/docs/api/browser-auth.md
+++ b/docs/api/browser-auth.md
@@ -17,21 +17,21 @@ function browserAuth(options?: BrowserAuthOptions): OAuthClientProvider;
 
 ### BrowserAuthOptions
 
-| Property       | Type                     | Default           | Description                        |
-| -------------- | ------------------------ | ----------------- | ---------------------------------- |
-| `clientId`     | `string`                 | _none_            | Pre-registered OAuth client ID     |
-| `clientSecret` | `string`                 | _none_            | Pre-registered OAuth client secret |
-| `scope`        | `string`                 | _none_            | OAuth scopes to request            |
-| `port`         | `number`                 | `3000`            | Port for local callback server     |
-| `hostname`     | `string`                 | `"localhost"`     | Hostname to bind server to         |
-| `callbackPath` | `string`                 | `"/callback"`     | URL path for OAuth callback        |
-| `store`        | `TokenStore`             | `inMemoryStore()` | Token storage implementation       |
-| `storeKey`     | `string`                 | `"mcp-tokens"`    | Storage key for token isolation    |
-| `launch`       | `(url: string) => unknown` | _none_          | Callback to launch auth URL        |
-| `authTimeout`  | `number`                 | `300000`          | Auth timeout in ms (5 min)         |
-| `successHtml`  | `string`                 | _built-in_        | Custom success page HTML           |
-| `errorHtml`    | `string`                 | _built-in_        | Custom error page HTML             |
-| `onRequest`    | `(req: Request) => void` | _none_            | Request logging callback           |
+| Property       | Type                       | Default           | Description                        |
+| -------------- | -------------------------- | ----------------- | ---------------------------------- |
+| `clientId`     | `string`                   | _none_            | Pre-registered OAuth client ID     |
+| `clientSecret` | `string`                   | _none_            | Pre-registered OAuth client secret |
+| `scope`        | `string`                   | _none_            | OAuth scopes to request            |
+| `port`         | `number`                   | `3000`            | Port for local callback server     |
+| `hostname`     | `string`                   | `"localhost"`     | Hostname to bind server to         |
+| `callbackPath` | `string`                   | `"/callback"`     | URL path for OAuth callback        |
+| `store`        | `TokenStore`               | `inMemoryStore()` | Token storage implementation       |
+| `storeKey`     | `string`                   | `"mcp-tokens"`    | Storage key for token isolation    |
+| `launch`       | `(url: string) => unknown` | _none_            | Callback to launch auth URL        |
+| `authTimeout`  | `number`                   | `300000`          | Auth timeout in ms (5 min)         |
+| `successHtml`  | `string`                   | _built-in_        | Custom success page HTML           |
+| `errorHtml`    | `string`                   | _built-in_        | Custom error page HTML             |
+| `onRequest`    | `(req: Request) => void`   | _none_            | Request logging callback           |
 
 ## Return Value
 

--- a/docs/api/get-auth-code.md
+++ b/docs/api/get-auth-code.md
@@ -31,7 +31,7 @@ The function accepts either:
 | `hostname`         | `string`                 | `"localhost"` | Hostname to bind the server to                |
 | `callbackPath`     | `string`                 | `"/callback"` | URL path for OAuth callback                   |
 | `timeout`          | `number`                 | `30000`       | Timeout in milliseconds                       |
-| `openBrowser`      | `boolean`                | `true`        | Auto-open browser to auth URL                 |
+| `launch`           | `(url: string) => unknown` | _none_      | Optional callback to launch auth URL          |
 | `successHtml`      | `string`                 | _built-in_    | Custom HTML for successful auth               |
 | `errorHtml`        | `string`                 | _built-in_    | Custom HTML template for errors               |
 | `signal`           | `AbortSignal`            | _none_        | For programmatic cancellation                 |
@@ -62,11 +62,12 @@ The function can throw:
 
 ## Basic Usage
 
-### Simple Authorization
+### With Browser Launch
 
-The simplest usage with just an authorization URL:
+The recommended usage with automatic browser opening:
 
 ```typescript
+import open from "open";
 import { getAuthCode } from "oauth-callback";
 
 const authUrl =
@@ -78,7 +79,7 @@ const authUrl =
     state: "random_state",
   });
 
-const result = await getAuthCode(authUrl);
+const result = await getAuthCode({ authorizationUrl: authUrl, launch: open });
 console.log("Authorization code:", result.code);
 console.log("State:", result.state);
 ```
@@ -245,19 +246,27 @@ try {
 }
 ```
 
-### Manual Browser Control
+### Headless / Manual Browser Control
 
-For environments where automatic browser opening doesn't work:
+For environments where you want to handle browser opening yourself:
 
 ```typescript
-const result = await getAuthCode({
-  authorizationUrl: authUrl,
-  openBrowser: false, // Don't auto-open
-});
-
-// Manually instruct user
+// Headless mode - print URL, let user open manually
 console.log("Please open this URL in your browser:");
 console.log(authUrl);
+
+const result = await getAuthCode({ authorizationUrl: authUrl });
+```
+
+Or use a custom launcher:
+
+```typescript
+import open from "open";
+
+const result = await getAuthCode({
+  authorizationUrl: authUrl,
+  launch: open, // Pass any function that accepts URL
+});
 ```
 
 ## Error Handling
@@ -267,10 +276,11 @@ console.log(authUrl);
 Handle all possible error scenarios:
 
 ```typescript
+import open from "open";
 import { getAuthCode, OAuthError } from "oauth-callback";
 
 try {
-  const result = await getAuthCode(authUrl);
+  const result = await getAuthCode({ authorizationUrl: authUrl, launch: open });
   // Success - exchange code for token
   return result.code;
 } catch (error) {
@@ -564,7 +574,7 @@ describe("OAuth Flow", () => {
     const result = await getAuthCode({
       authorizationUrl: `http://localhost:${mockServer.port}/authorize`,
       port: 3001,
-      openBrowser: false, // Don't open real browser in tests
+      // No launch callback - tests simulate OAuth redirect
       timeout: 5000,
     });
 
@@ -583,7 +593,7 @@ describe("OAuth Flow", () => {
     await expect(
       getAuthCode({
         authorizationUrl: `http://localhost:${mockServer.port}/authorize`,
-        openBrowser: false,
+        // No launch - test simulates OAuth redirect
       }),
     ).rejects.toThrow(OAuthError);
 

--- a/docs/api/get-auth-code.md
+++ b/docs/api/get-auth-code.md
@@ -24,18 +24,18 @@ The function accepts either:
 
 ### GetAuthCodeOptions
 
-| Property           | Type                     | Default       | Description                                   |
-| ------------------ | ------------------------ | ------------- | --------------------------------------------- |
-| `authorizationUrl` | `string`                 | _required_    | OAuth authorization URL with query parameters |
-| `port`             | `number`                 | `3000`        | Port for the local callback server            |
-| `hostname`         | `string`                 | `"localhost"` | Hostname to bind the server to                |
-| `callbackPath`     | `string`                 | `"/callback"` | URL path for OAuth callback                   |
-| `timeout`          | `number`                 | `30000`       | Timeout in milliseconds                       |
-| `launch`           | `(url: string) => unknown` | _none_      | Optional callback to launch auth URL          |
-| `successHtml`      | `string`                 | _built-in_    | Custom HTML for successful auth               |
-| `errorHtml`        | `string`                 | _built-in_    | Custom HTML template for errors               |
-| `signal`           | `AbortSignal`            | _none_        | For programmatic cancellation                 |
-| `onRequest`        | `(req: Request) => void` | _none_        | Callback for request logging                  |
+| Property           | Type                       | Default       | Description                                   |
+| ------------------ | -------------------------- | ------------- | --------------------------------------------- |
+| `authorizationUrl` | `string`                   | _required_    | OAuth authorization URL with query parameters |
+| `port`             | `number`                   | `3000`        | Port for the local callback server            |
+| `hostname`         | `string`                   | `"localhost"` | Hostname to bind the server to                |
+| `callbackPath`     | `string`                   | `"/callback"` | URL path for OAuth callback                   |
+| `timeout`          | `number`                   | `30000`       | Timeout in milliseconds                       |
+| `launch`           | `(url: string) => unknown` | _none_        | Optional callback to launch auth URL          |
+| `successHtml`      | `string`                   | _built-in_    | Custom HTML for successful auth               |
+| `errorHtml`        | `string`                   | _built-in_    | Custom HTML template for errors               |
+| `signal`           | `AbortSignal`              | _none_        | For programmatic cancellation                 |
+| `onRequest`        | `(req: Request) => void`   | _none_        | Callback for request logging                  |
 
 ## Return Value
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -369,7 +369,11 @@ const authProvider = browserAuth({
 function createAuthProvider(env: "dev" | "staging" | "prod") {
   const configs = {
     dev: { launch: open, port: 3000, store: inMemoryStore() },
-    staging: { launch: open, port: 3001, store: fileStore("~/.mcp/staging.json") },
+    staging: {
+      launch: open,
+      port: 3001,
+      store: fileStore("~/.mcp/staging.json"),
+    },
     prod: { launch: open, port: 3002, store: fileStore("~/.mcp/prod.json") },
   };
   return browserAuth(configs[env]);

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -39,12 +39,14 @@ OAuth Callback supports multiple import patterns to suit different use cases:
 ### Main Package Import
 
 ```typescript
+import open from "open";
+
 // Core functionality
 import { getAuthCode, OAuthError } from "oauth-callback";
 
 // Namespace import for MCP features
 import { mcp } from "oauth-callback";
-const authProvider = mcp.browserAuth({ store: mcp.fileStore() });
+const authProvider = mcp.browserAuth({ launch: open, store: mcp.fileStore() });
 ```
 
 ### MCP-Specific Import
@@ -88,7 +90,7 @@ function browserAuth(options?: BrowserAuthOptions): OAuthClientProvider;
 **Key Features:**
 
 - Dynamic Client Registration (RFC 7591)
-- Automatic token refresh
+- Automatic token expiry handling
 - PKCE support (RFC 7636)
 - Flexible token storage
 - MCP SDK integration
@@ -129,6 +131,7 @@ Ephemeral storage that keeps tokens in memory:
 
 ```typescript
 const authProvider = browserAuth({
+  launch: open,
   store: inMemoryStore(), // Tokens lost on restart
 });
 ```
@@ -139,6 +142,7 @@ Persistent storage that saves tokens to a JSON file:
 
 ```typescript
 const authProvider = browserAuth({
+  launch: open,
   store: fileStore(), // Default: ~/.mcp/tokens.json
 });
 ```
@@ -179,7 +183,7 @@ interface GetAuthCodeOptions {
   hostname?: string;
   callbackPath?: string;
   timeout?: number;
-  openBrowser?: boolean;
+  launch?: (url: string) => unknown;
   successHtml?: string;
   errorHtml?: string;
   signal?: AbortSignal;
@@ -229,10 +233,12 @@ console.log("Code:", result.code);
 ### MCP Integration
 
 ```typescript
+import open from "open";
 import { browserAuth, fileStore } from "oauth-callback/mcp";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 
 const authProvider = browserAuth({
+  launch: open,
   store: fileStore(),
   scope: "read write",
 });
@@ -274,6 +280,7 @@ class RedisStore implements TokenStore {
 }
 
 const authProvider = browserAuth({
+  launch: open,
   store: new RedisStore(),
 });
 ```
@@ -301,6 +308,7 @@ if (result.state !== state) {
 
 // Use ephemeral storage for maximum security
 const authProvider = browserAuth({
+  launch: open,
   store: inMemoryStore(), // No disk persistence
 });
 
@@ -349,6 +357,7 @@ Automatically register OAuth clients without pre-configuration:
 ```typescript
 // No client_id or client_secret needed!
 const authProvider = browserAuth({
+  launch: open,
   scope: "read write",
   store: fileStore(),
 });
@@ -359,9 +368,9 @@ const authProvider = browserAuth({
 ```typescript
 function createAuthProvider(env: "dev" | "staging" | "prod") {
   const configs = {
-    dev: { port: 3000, store: inMemoryStore() },
-    staging: { port: 3001, store: fileStore("~/.mcp/staging.json") },
-    prod: { port: 3002, store: fileStore("~/.mcp/prod.json") },
+    dev: { launch: open, port: 3000, store: inMemoryStore() },
+    staging: { launch: open, port: 3001, store: fileStore("~/.mcp/staging.json") },
+    prod: { launch: open, port: 3002, store: fileStore("~/.mcp/prod.json") },
   };
   return browserAuth(configs[env]);
 }
@@ -371,6 +380,7 @@ function createAuthProvider(env: "dev" | "staging" | "prod") {
 
 ```typescript
 const authProvider = browserAuth({
+  launch: open,
   onRequest: (req) => {
     const url = new URL(req.url);
     console.log(`[OAuth] ${req.method} ${url.pathname}`);
@@ -401,7 +411,7 @@ class CustomOAuthProvider {
 }
 
 // After: Using browserAuth
-const authProvider = browserAuth({ store: fileStore() });
+const authProvider = browserAuth({ launch: open, store: fileStore() });
 ```
 
 ## API Stability

--- a/docs/api/types.md
+++ b/docs/api/types.md
@@ -58,7 +58,7 @@ interface GetAuthCodeOptions {
   hostname?: string; // Hostname (default: "localhost")
   callbackPath?: string; // Callback path (default: "/callback")
   timeout?: number; // Timeout in ms (default: 30000)
-  openBrowser?: boolean; // Auto-open browser (default: true)
+  launch?: (url: string) => unknown; // Optional URL launcher
   successHtml?: string; // Custom success HTML
   errorHtml?: string; // Custom error HTML template
   signal?: AbortSignal; // Cancellation signal
@@ -391,12 +391,11 @@ interface BrowserAuthOptions {
 
   // Storage
   store?: TokenStore; // Token storage
-  storeKey?: string; // Storage key prefix
+  storeKey?: string; // Storage key for token isolation
 
   // Behavior
-  openBrowser?: boolean | string; // Browser control
+  launch?: (url: string) => unknown; // URL launcher
   authTimeout?: number; // Timeout ms (default: 300000)
-  usePKCE?: boolean; // Enable PKCE (default: true)
 
   // UI
   successHtml?: string; // Success page HTML
@@ -425,8 +424,7 @@ const options: BrowserAuthOptions = {
   store: fileStore("~/.myapp/tokens.json"),
   storeKey: "production",
 
-  // Security
-  usePKCE: true,
+  // Timeout
   authTimeout: 600000, // 10 minutes
 
   // Custom UI

--- a/docs/blog/03-browser-auto-open.md
+++ b/docs/blog/03-browser-auto-open.md
@@ -1,6 +1,6 @@
 ---
 link: https://dev.to/kriasoft/browser-auto-open-seamless-oauth-ux-for-cli-tools-3nh4
-title: Browser Auto-Open: Seamless OAuth UX for CLI Tools
+title: "Browser Auto-Open: Seamless OAuth UX for CLI Tools"
 date: 2025-01-20
 author: Konstantin Tarkus
 tags: [oauth, cli, ux, authentication, browser]

--- a/docs/blog/03-browser-auto-open.md
+++ b/docs/blog/03-browser-auto-open.md
@@ -33,29 +33,28 @@ open(url, { wait: false });
 
 Under the hood, `open` handles an impressive array of edge cases. It detects WSL and uses `powershell.exe` to launch Windows browsers. It respects the `BROWSER` environment variable for Linux users who've customized their setup. It even handles spaces in URLs and special characters that would break naive implementations.
 
-## Smart Defaults with Escape Hatches
+## Explicit Control with Escape Hatches
 
-The key to great developer experience is making the common case trivial while keeping the complex cases possible. In `oauth-callback`, browser launching is enabled by default but fully configurable:
+The key to great developer experience is making the common case trivial while keeping the complex cases possible. In `oauth-callback`, browser launching is explicit via the `launch` callback:
 
 ```typescript
-// Default behavior - just works
+import open from "open";
+
+// Default behavior - pass open as launcher
 const result = await getAuthCode({
   authorizationUrl: "https://oauth.example.com/authorize?...",
+  launch: open,
 });
 
-// Disable for CI/headless environments
-const result = await getAuthCode({
-  authorizationUrl: url,
-  openBrowser: false, // User must manually open the URL
-});
+// Headless/CI environments - omit launch, print URL manually
+console.log(`Please open: ${url}`);
+const result = await getAuthCode({ authorizationUrl: url });
 
 // Custom browser handling
 const result = await getAuthCode({
   authorizationUrl: url,
-  openBrowser: false,
+  launch: (url) => myCustomBrowserLauncher(url),
 });
-// Implement your own logic
-await myCustomBrowserLauncher(url);
 ```
 
 This flexibility becomes crucial in different environments. CI systems often run headless, so automatic browser launching would fail. Some users prefer copying URLs to browsers on different machines. Others might be running in containers or SSH sessions where browser access is impossible.
@@ -65,14 +64,14 @@ This flexibility becomes crucial in different environments. CI systems often run
 Browser launching can fail for numerous reasons: the system might be headless, the user might have unusual configurations, or security policies might block the operation. Rather than crashing, provide a fallback:
 
 ```typescript
-async function launchBrowser(url: string, options: GetAuthCodeOptions) {
-  if (!options.openBrowser) {
+async function launchBrowser(url: string, launch?: (url: string) => unknown) {
+  if (!launch) {
     console.log(`Please open this URL in your browser:\n${url}`);
     return;
   }
 
   try {
-    await open(url);
+    await launch(url);
     console.log("Opening browser...");
   } catch (error) {
     // Fallback to manual URL opening
@@ -99,13 +98,11 @@ export async function getAuthCode(options: GetAuthCodeOptions) {
       hostname: options.hostname,
     });
 
-    // Launch browser without waiting
-    if (options.openBrowser) {
-      // Don't await - let it run in parallel
-      open(options.authorizationUrl).catch(() => {
-        // Log but don't fail
-        console.log("Note: Could not open browser automatically");
-      });
+    // Launch browser without waiting (best-effort)
+    if (options.launch) {
+      Promise.resolve()
+        .then(() => options.launch(options.authorizationUrl))
+        .catch(() => {});
     }
 
     // Server is ready regardless of browser status
@@ -125,15 +122,15 @@ This pattern ensures your callback server is always ready, even if the browser t
 
 ## Testing Without Real Browsers
 
-Automated testing shouldn't spawn actual browser windows. The `openBrowser` flag enables test-friendly behavior:
+Automated testing shouldn't spawn actual browser windows. Simply omit the `launch` callback:
 
 ```typescript
-// In tests
+// In tests - omit launch to prevent browser
 const mockProvider = new MockOAuthProvider();
 
 const result = await getAuthCode({
   authorizationUrl: mockProvider.authUrl,
-  openBrowser: false, // Prevent browser launch
+  // No launch - tests simulate OAuth redirect directly
   port: 0, // Use random available port
 });
 
@@ -146,23 +143,22 @@ await mockProvider.completeAuth({
 expect(result.code).toBe("test-auth-code");
 ```
 
-For integration with Model Context Protocol servers or other automation scenarios, you might want programmatic control:
+For integration with Model Context Protocol servers or other automation scenarios:
 
 ```typescript
+import open from "open";
+
 export const browserAuth = () => ({
   async authenticate(params: AuthenticateParams) {
-    const options = {
+    const launch = process.env.CI
+      ? () => params.onAuthUrl(params.url) // Let MCP client display URL
+      : open;
+
+    return getAuthCode({
       authorizationUrl: params.url,
-      openBrowser: process.env.CI ? false : true,
+      launch,
       timeout: params.timeout,
-    };
-
-    if (!options.openBrowser) {
-      // MCP client handles URL display
-      await params.onAuthUrl(params.url);
-    }
-
-    return getAuthCode(options);
+    });
   },
 });
 ```

--- a/docs/core-concepts.md
+++ b/docs/core-concepts.md
@@ -54,8 +54,10 @@ OAuth Callback creates a temporary HTTP server on localhost that:
 4. **Handles edge cases**: Timeouts, errors, user cancellation
 
 ```typescript
+import open from "open";
+
 // This single function handles all the complexity
-const result = await getAuthCode(authorizationUrl);
+const result = await getAuthCode({ authorizationUrl, launch: open });
 ```
 
 ## Architecture Overview
@@ -120,7 +122,7 @@ interface GetAuthCodeOptions {
   authorizationUrl: string; // OAuth provider URL
   port?: number; // Server port (default: 3000)
   timeout?: number; // Timeout in ms (default: 30000)
-  openBrowser?: boolean; // Auto-open browser (default: true)
+  launch?: (url: string) => unknown; // Optional URL launcher
   signal?: AbortSignal; // For cancellation
   // ... more options
 }
@@ -190,10 +192,8 @@ stateDiagram-v2
     [*] --> NoToken: Initial State
     NoToken --> Authorizing: User initiates OAuth
     Authorizing --> HasToken: Successful auth
-    HasToken --> Refreshing: Token expired
-    Refreshing --> HasToken: Token refreshed
+    HasToken --> Authorizing: Token expired
     HasToken --> NoToken: User logs out
-    Refreshing --> Authorizing: Refresh failed
 ```
 
 ## MCP Integration Pattern
@@ -326,7 +326,7 @@ if (!isLocalhost(request.socket.remoteAddress)) {
 - **Memory storage option**: No persistence
 - **File permissions**: Restrictive when using file store
 - **No logging**: Tokens never logged or exposed
-- **Refresh handling**: Automatic token refresh
+- **Expiry handling**: Automatic re-auth when tokens expire
 
 ## Template System
 
@@ -448,15 +448,19 @@ Monitor or modify requests with callbacks:
 }
 ```
 
-### Browser Control
+### Custom URL Launcher
 
-Customize browser launching:
+Customize how the authorization URL is opened:
 
 ```typescript
-{
-  openBrowser: false,  // Manual browser opening
-  // Or provide custom launcher
-}
+import open from "open";
+
+// Use system browser
+await getAuthCode({ authorizationUrl, launch: open });
+
+// Headless mode - omit launch, print URL manually
+console.log(`Open: ${authorizationUrl}`);
+await getAuthCode({ authorizationUrl });
 ```
 
 ## Best Practices

--- a/docs/examples/linear.md
+++ b/docs/examples/linear.md
@@ -81,6 +81,7 @@ Select scopes based on your needs:
 Here's a basic example connecting to Linear's MCP server:
 
 ```typescript
+import open from "open";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { browserAuth, fileStore } from "oauth-callback/mcp";
@@ -93,6 +94,7 @@ async function connectToLinear() {
 
   // Create OAuth provider with credentials
   const authProvider = browserAuth({
+    launch: open,
     clientId: process.env.LINEAR_CLIENT_ID,
     clientSecret: process.env.LINEAR_CLIENT_SECRET,
     scope: "read write issues:create issues:update",
@@ -172,6 +174,9 @@ Configure the OAuth provider for Linear:
 
 ```typescript
 const authProvider = browserAuth({
+  // Browser launch callback
+  launch: open,
+
   // OAuth credentials
   clientId: process.env.LINEAR_CLIENT_ID,
   clientSecret: process.env.LINEAR_CLIENT_SECRET,
@@ -190,9 +195,6 @@ const authProvider = browserAuth({
 
   // Timeouts
   authTimeout: 300000, // 5 minutes
-
-  // Security
-  usePKCE: true, // Recommended for public clients
 
   // Debugging
   onRequest(req) {
@@ -335,6 +337,7 @@ client.on("resource_updated", (resource) => {
 Create a reusable Linear MCP client:
 
 ```typescript
+import open from "open";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { browserAuth, fileStore } from "oauth-callback/mcp";
@@ -349,6 +352,7 @@ class LinearMCPClient {
     storePath?: string;
   }) {
     this.authProvider = browserAuth({
+      launch: open,
       clientId: options?.clientId || process.env.LINEAR_CLIENT_ID,
       clientSecret: options?.clientSecret || process.env.LINEAR_CLIENT_SECRET,
       scope: "read write issues:create issues:update",
@@ -751,10 +755,12 @@ LINEAR_TEAM_ID=team_eng
 
 ```typescript
 // Load configuration
+import open from "open";
 import { config } from "dotenv";
 config();
 
 const authProvider = browserAuth({
+  launch: open,
   clientId: process.env.LINEAR_CLIENT_ID!,
   clientSecret: process.env.LINEAR_CLIENT_SECRET!,
   scope: "read write",
@@ -833,6 +839,7 @@ Check your Linear OAuth app configuration:
 ```typescript
 // Verify redirect URI matches
 const authProvider = browserAuth({
+  launch: open,
   clientId: "...",
   clientSecret: "...",
   port: 3000, // Must match redirect URI port
@@ -878,6 +885,7 @@ Handle token refresh errors:
 
 ```typescript
 const authProvider = browserAuth({
+  launch: open,
   store: fileStore(),
   onTokenRefreshError: async (error) => {
     console.error("Token refresh failed:", error);

--- a/docs/examples/notion.md
+++ b/docs/examples/notion.md
@@ -79,6 +79,7 @@ Here's the full implementation demonstrating Notion MCP integration:
 
 ```typescript
 #!/usr/bin/env bun
+import open from "open";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { browserAuth, inMemoryStore } from "oauth-callback/mcp";
@@ -90,6 +91,7 @@ async function connectToNotion() {
 
   // Create OAuth provider - no client_id or client_secret needed!
   const authProvider = browserAuth({
+    launch: open,
     port: 3000,
     scope: "read write",
     store: inMemoryStore(), // Use fileStore() for persistence
@@ -191,7 +193,10 @@ Unlike traditional OAuth, Notion's MCP server supports Dynamic Client Registrati
 The `browserAuth()` provider handles the complete OAuth flow:
 
 ```typescript
+import open from "open";
+
 const authProvider = browserAuth({
+  launch: open, // Opens browser for authorization
   port: 3000, // Callback server port
   scope: "read write", // Requested permissions
   store: inMemoryStore(), // Token storage
@@ -211,6 +216,7 @@ Choose between ephemeral and persistent storage:
 ```typescript [Ephemeral Storage]
 // Tokens lost on restart (more secure)
 const authProvider = browserAuth({
+  launch: open,
   store: inMemoryStore(),
 });
 ```
@@ -220,6 +226,7 @@ const authProvider = browserAuth({
 import { fileStore } from "oauth-callback/mcp";
 
 const authProvider = browserAuth({
+  launch: open,
   store: fileStore(), // Default: ~/.mcp/tokens.json
 });
 ```
@@ -227,6 +234,7 @@ const authProvider = browserAuth({
 ```typescript [Custom Location]
 // Specify custom file path
 const authProvider = browserAuth({
+  launch: open,
   store: fileStore("~/my-app/notion-tokens.json"),
 });
 ```
@@ -378,11 +386,11 @@ const workAuth = createNotionAuth("work");
 
 ::: details Browser doesn't open automatically
 
-If the browser doesn't open automatically:
+If you're in a headless environment:
 
 ```typescript
 const authProvider = browserAuth({
-  openBrowser: false, // Disable auto-open
+  launch: () => {}, // Noop - disable browser opening
 });
 
 // Manually instruct user

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -126,7 +126,10 @@ async function authenticate() {
   try {
     // Get authorization code
     console.log("Opening browser for authentication...");
-    const result = await getAuthCode({ authorizationUrl: authUrl.toString(), launch: open });
+    const result = await getAuthCode({
+      authorizationUrl: authUrl.toString(),
+      launch: open,
+    });
 
     // Validate state
     if (result.state !== state) {

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -22,28 +22,31 @@ Install the package using your preferred package manager:
 ::: code-group
 
 ```bash [Bun]
-bun add oauth-callback
+bun add oauth-callback open
 ```
 
 ```bash [npm]
-npm install oauth-callback
+npm install oauth-callback open
 ```
 
 ```bash [pnpm]
-pnpm add oauth-callback
+pnpm add oauth-callback open
 ```
 
 ```bash [Yarn]
-yarn add oauth-callback
+yarn add oauth-callback open
 ```
 
 :::
+
+> **Note:** The `open` package is optional but recommended for launching the browser. Omit it for headless environments.
 
 ## Basic Usage
 
 The simplest way to capture an OAuth authorization code is with the `getAuthCode()` function:
 
 ```typescript
+import open from "open";
 import { getAuthCode } from "oauth-callback";
 
 // Construct your OAuth authorization URL
@@ -56,8 +59,8 @@ const authUrl =
     state: crypto.randomUUID(), // For CSRF protection
   });
 
-// Get the authorization code
-const result = await getAuthCode(authUrl);
+// Get the authorization code (launch: open opens the browser)
+const result = await getAuthCode({ authorizationUrl: authUrl, launch: open });
 
 console.log("Authorization code:", result.code);
 console.log("State:", result.state);
@@ -106,6 +109,7 @@ First, register your application with your OAuth provider:
 Create a file `auth.ts` with your OAuth implementation:
 
 ```typescript
+import open from "open";
 import { getAuthCode, OAuthError } from "oauth-callback";
 
 async function authenticate() {
@@ -122,7 +126,7 @@ async function authenticate() {
   try {
     // Get authorization code
     console.log("Opening browser for authentication...");
-    const result = await getAuthCode(authUrl.toString());
+    const result = await getAuthCode({ authorizationUrl: authUrl.toString(), launch: open });
 
     // Validate state
     if (result.state !== state) {
@@ -215,12 +219,14 @@ For Model Context Protocol applications, use the `browserAuth()` provider for se
 ### Quick Setup
 
 ```typescript
+import open from "open";
 import { browserAuth, inMemoryStore } from "oauth-callback/mcp";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 
 // Create OAuth provider for MCP
 const authProvider = browserAuth({
+  launch: open,
   store: inMemoryStore(), // Or fileStore() for persistence
   scope: "read write",
 });
@@ -373,10 +379,11 @@ try {
 Proper error handling ensures a good user experience:
 
 ```typescript
+import open from "open";
 import { getAuthCode, OAuthError } from "oauth-callback";
 
 try {
-  const result = await getAuthCode(authUrl);
+  const result = await getAuthCode({ authorizationUrl: authUrl, launch: open });
   // Success path
 } catch (error) {
   if (error instanceof OAuthError) {
@@ -511,15 +518,12 @@ Also update your OAuth app's redirect URI to match.
 :::
 
 ::: details Browser Doesn't Open
-If the browser doesn't open automatically:
+If you're in a headless environment or the browser doesn't open:
 
 ```typescript
-const result = await getAuthCode({
-  authorizationUrl: authUrl,
-  openBrowser: false, // Disable auto-open
-});
-
+// Headless mode - print URL for manual opening
 console.log(`Please open: ${authUrl}`);
+const result = await getAuthCode({ authorizationUrl: authUrl });
 ```
 
 :::

--- a/docs/what-is-oauth-callback.md
+++ b/docs/what-is-oauth-callback.md
@@ -161,7 +161,7 @@ The MCP integration handles:
 
 - **Dynamic Client Registration** when supported by the server
 - **Token persistence** with `fileStore()` or ephemeral `inMemoryStore()`
-- **Automatic token refresh** when tokens expire
+- **Automatic re-authentication** when tokens expire
 - **Multiple app namespace support** via `storeKey` option
   :::
 

--- a/examples/demo.ts
+++ b/examples/demo.ts
@@ -11,6 +11,7 @@
  * or external OAuth providers. Perfect for testing and learning.
  */
 
+import open from "open";
 import { getAuthCode, OAuthError } from "../src/index";
 import type { Server } from "bun";
 
@@ -274,12 +275,10 @@ async function runScenario(
       resultPromise = getAuthCode({
         authorizationUrl: authUrl.toString(),
         port: 3000,
-        openBrowser: true,
+        launch: open,
         timeout: 10000,
-        // Using default templates to showcase the enhanced UI
         onRequest: (req) => {
           const url = new URL(req.url);
-          // Only log the actual callback, not favicon requests
           if (url.pathname === "/callback") {
             console.log(
               `   Callback received: ${url.pathname}${url.search.slice(0, 50)}...`,
@@ -292,7 +291,6 @@ async function runScenario(
       resultPromise = getAuthCode({
         authorizationUrl: authUrl.toString(),
         port: 3000,
-        openBrowser: false,
         timeout: 10000,
         onRequest: (req) => {
           const url = new URL(req.url);
@@ -304,22 +302,15 @@ async function runScenario(
         },
       });
 
-      // Wait a bit for the server to start, then manually call the authorization endpoint
-      // which will generate the callback URL
+      // Wait for server to start, then simulate OAuth provider redirect
       await new Promise((resolve) => setTimeout(resolve, 500));
-
-      // Fetch the authorization endpoint to get the callback URL
       const authResponse = await fetch(authUrl.toString());
       const authHtml = await authResponse.text();
-
-      // Extract the callback URL from the HTML response
       const callbackMatch = authHtml.match(
         /window\.location\.href = "([^"]+)"/,
       );
       if (callbackMatch) {
-        const callbackUrl = callbackMatch[1];
-        // Manually trigger the callback
-        await fetch(callbackUrl);
+        await fetch(callbackMatch[1]);
       }
     }
 

--- a/examples/github.ts
+++ b/examples/github.ts
@@ -14,6 +14,7 @@
  *   bun run example.ts
  */
 
+import open from "open";
 import { getAuthCode, OAuthError } from "../src/index";
 
 // Check for required environment variables
@@ -51,7 +52,8 @@ async function main() {
     const result = await getAuthCode({
       authorizationUrl: authUrl.toString(),
       port: 3000,
-      timeout: 60000, // 1 minute timeout
+      timeout: 60000,
+      launch: open,
       onRequest: (req) => {
         const url = new URL(req.url);
         console.log(`📨 Received ${req.method} request to ${url.pathname}`);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oauth-callback",
-  "version": "1.2.5",
+  "version": "2.0.0",
   "description": "Lightweight OAuth 2.0 callback handler for Node.js, Deno, and Bun with built-in browser flow and MCP SDK integration",
   "keywords": [
     "oauth",
@@ -52,6 +52,10 @@
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
   "type": "module",
+  "sideEffects": false,
+  "engines": {
+    "node": ">=18"
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -62,9 +66,6 @@
       "default": "./dist/mcp.js"
     },
     "./package.json": "./package.json"
-  },
-  "dependencies": {
-    "open": "^11.0.0"
   },
   "peerDependencies": {
     "@modelcontextprotocol/sdk": ">=1.17.0 <2",
@@ -80,17 +81,17 @@
   },
   "devDependencies": {
     "@modelcontextprotocol/sdk": "^1.25.3",
+    "open": "^11.0.0",
     "@types/bun": "^1.3.6",
     "@types/deno": "^2.5.0",
     "@types/node": "^25.0.10",
-    "@types/open": "^6.2.1",
     "bun-types": "^1.2.20",
     "mermaid": "^11.12.2",
     "prettier": "^3.8.1",
     "publint": "^0.3.17",
     "srcpack": "^0.1.13",
     "typescript": "^5.9.3",
-    "vitepress": "^1.6.4",
+    "vitepress": "^2.0.0-alpha.15",
     "vitepress-plugin-mermaid": "^2.0.17"
   },
   "prettier": {
@@ -119,6 +120,6 @@
     "docs:dev": "vitepress dev docs",
     "docs:build": "vitepress build docs",
     "docs:preview": "vitepress preview docs",
-    "docs:publish": "bunx gh-pages -d docs/.vitepress/dist"
+    "docs:deploy": "bunx gh-pages -d docs/.vitepress/dist"
   }
 }

--- a/scripts/test-login.ts
+++ b/scripts/test-login.ts
@@ -9,6 +9,7 @@
  * Run with: bun test:login
  */
 
+import open from "open";
 import { getAuthCode } from "../src/index";
 
 const OAUTH_PORT = 8765;
@@ -65,6 +66,7 @@ try {
     authorizationUrl: authUrl,
     port: CALLBACK_PORT,
     timeout: 60000,
+    launch: open,
   });
 
   console.log("✅ Success!");

--- a/src/auth/browser-auth.ts
+++ b/src/auth/browser-auth.ts
@@ -13,7 +13,6 @@ import type {
 import { calculateExpiry } from "../utils/token";
 import { inMemoryStore } from "../storage/memory";
 import { getAuthCode } from "../index";
-import { OAuthError } from "../errors";
 import type { OAuthClientProvider } from "@modelcontextprotocol/sdk/client/auth.js";
 import type {
   OAuthClientInformation,
@@ -30,9 +29,11 @@ import type {
  *
  * @example
  * ```typescript
+ * import open from "open";
+ *
  * const transport = new StreamableHTTPClientTransport(
  *   new URL("https://mcp.notion.com/mcp"),
- *   { authProvider: browserAuth() }
+ *   { authProvider: browserAuth({ launch: open }) }
  * );
  * ```
  */
@@ -44,6 +45,7 @@ export function browserAuth(
 
 /**
  * Browser-based OAuth provider for MCP SDK.
+ * @invariant PKCE is always enabled (SDK calls saveCodeVerifier/codeVerifier).
  * @invariant addClientAuthentication() must remain undefined (SDK constraint).
  * @invariant Concurrent auth/refresh attempts are serialized.
  */
@@ -54,8 +56,7 @@ class BrowserOAuthProvider implements OAuthClientProvider {
   private readonly _hostname: string;
   private readonly _callbackPath: string;
   private readonly _authTimeout: number;
-  private readonly _usePKCE: boolean;
-  private readonly _openBrowser: boolean | string;
+  private readonly _launch?: (url: string) => unknown;
   private readonly _clientId?: string;
   private readonly _clientSecret?: string;
   private readonly _scope?: string;
@@ -73,7 +74,6 @@ class BrowserOAuthProvider implements OAuthClientProvider {
   private _tokensLoaded = false;
   private _loadingTokens?: Promise<void>;
   private _authInProgress?: Promise<void>;
-  private _refreshInProgress?: Promise<void>;
 
   constructor(options: BrowserAuthOptions = {}) {
     this._store = options.store ?? inMemoryStore();
@@ -82,9 +82,7 @@ class BrowserOAuthProvider implements OAuthClientProvider {
     this._hostname = options.hostname ?? "localhost";
     this._callbackPath = options.callbackPath ?? "/callback";
     this._authTimeout = options.authTimeout ?? 300000;
-    this._usePKCE = options.usePKCE ?? true;
-    this._openBrowser = options.openBrowser ?? true;
-
+    this._launch = options.launch;
     this._clientId = options.clientId;
     this._clientSecret = options.clientSecret;
     this._scope = options.scope;
@@ -123,7 +121,7 @@ class BrowserOAuthProvider implements OAuthClientProvider {
       // Load client info if using extended store
       if (this._isOAuthStore(this._store)) {
         const clientInfo = await this._store.getClient(this._storeKey);
-        if (clientInfo) {
+        if (clientInfo?.clientId) {
           this._clientInfo = {
             client_id: clientInfo.clientId,
             client_secret: clientInfo.clientSecret,
@@ -135,20 +133,24 @@ class BrowserOAuthProvider implements OAuthClientProvider {
 
         // Load session state
         const session = await this._store.getSession(this._storeKey);
-        if (session) {
+        if (session?.codeVerifier) {
           this._codeVerifier = session.codeVerifier;
         }
       }
 
       this._tokensLoaded = true;
-    } catch (error) {
-      console.warn("Failed to load stored data:", error);
+    } catch {
+      // Ignore store errors; fallback to fresh auth
       this._tokensLoaded = true;
     }
   }
 
   private _isOAuthStore(store: any): store is OAuthStore {
-    return typeof store.getClient === "function";
+    return (
+      typeof store.getClient === "function" &&
+      typeof store.setClient === "function" &&
+      typeof store.getSession === "function"
+    );
   }
 
   get redirectUrl(): string {
@@ -218,20 +220,9 @@ class BrowserOAuthProvider implements OAuthClientProvider {
 
     // Check expiry using stored expiresAt from initial token response
     const stored = await this._store.get(this._storeKey);
-    if (stored?.expiresAt) {
-      if (Date.now() >= stored.expiresAt - 60000) {
-        // Expired with 60s buffer
-        if (this._tokens.refresh_token) {
-          try {
-            await this._refreshTokens();
-            return this._tokens;
-          } catch (error) {
-            console.warn("Token refresh failed:", error);
-            return undefined;
-          }
-        }
-        return undefined;
-      }
+    if (stored?.expiresAt && Date.now() >= stored.expiresAt - 60000) {
+      // Token expired (with 60s buffer). Refresh not yet implemented — trigger re-auth.
+      return undefined;
     }
 
     return this._tokens;
@@ -269,59 +260,29 @@ class BrowserOAuthProvider implements OAuthClientProvider {
   }
 
   private async _doAuthorization(authorizationUrl: URL): Promise<void> {
-    let lastError: Error | undefined;
-    const maxRetries = 2;
+    const result = await getAuthCode({
+      authorizationUrl: authorizationUrl.href,
+      port: this._port,
+      hostname: this._hostname,
+      callbackPath: this._callbackPath,
+      timeout: this._authTimeout,
+      launch: this._launch,
+      successHtml: this._successHtml,
+      errorHtml: this._errorHtml,
+      onRequest: this._onRequest,
+    });
 
-    for (let attempt = 0; attempt <= maxRetries; attempt++) {
-      try {
-        const result = await getAuthCode({
-          authorizationUrl: authorizationUrl.href,
-          port: this._port,
-          hostname: this._hostname,
-          callbackPath: this._callbackPath,
-          timeout: this._authTimeout,
-          openBrowser:
-            typeof this._openBrowser === "boolean" ? this._openBrowser : true,
-          successHtml: this._successHtml,
-          errorHtml: this._errorHtml,
-          onRequest: this._onRequest,
-        });
+    /** Cache auth code for SDK's separate token exchange call. */
+    this._pendingAuthCode = result.code;
+    this._pendingAuthState = result.state;
 
-        /** Cache auth code for SDK's separate token exchange call. */
-        this._pendingAuthCode = result.code;
-        this._pendingAuthState = result.state;
-
-        /** Auto-cleanup stale auth codes after timeout to prevent leaks. */
-        setTimeout(() => {
-          if (this._pendingAuthCode === result.code) {
-            this._pendingAuthCode = undefined;
-            this._pendingAuthState = undefined;
-          }
-        }, this._authTimeout);
-
-        return;
-      } catch (error) {
-        lastError = error instanceof Error ? error : new Error(String(error));
-
-        if (error instanceof OAuthError) {
-          throw error; // OAuth errors are user-actionable, don't retry
-        }
-
-        if (attempt < maxRetries) {
-          console.warn(
-            `Auth attempt ${attempt + 1} failed, retrying...`,
-            error,
-          );
-          await new Promise((resolve) =>
-            setTimeout(resolve, 1000 * (attempt + 1)),
-          );
-        }
+    /** Auto-cleanup stale auth codes after timeout to prevent leaks. */
+    setTimeout(() => {
+      if (this._pendingAuthCode === result.code) {
+        this._pendingAuthCode = undefined;
+        this._pendingAuthState = undefined;
       }
-    }
-
-    throw new Error(
-      `OAuth authorization failed after ${maxRetries + 1} attempts: ${lastError?.message}`,
-    );
+    }, this._authTimeout);
   }
 
   async saveCodeVerifier(codeVerifier: string): Promise<void> {
@@ -348,8 +309,18 @@ class BrowserOAuthProvider implements OAuthClientProvider {
     scope: "all" | "client" | "tokens" | "verifier",
   ): Promise<void> {
     /**
-     * WORKAROUND: SDK calls invalidate("all") during token exchange.
-     * Must preserve client info and verifier until exchange completes.
+     * SDK behavioral dependency: The MCP SDK may call invalidate("all") during
+     * token exchange if the authorization server returns an error. The call
+     * sequence we protect against:
+     *
+     *   1. SDK calls getPendingAuthCode() → sets _isExchangingCode = true
+     *   2. SDK calls codeVerifier() to build token request
+     *   3. SDK sends token exchange request to authorization server
+     *   4. Server returns error → SDK calls invalidateCredentials("all")
+     *   5. SDK retries from step 2, but verifier is gone → permanent failure
+     *
+     * Without this guard, step 4 would clear the verifier needed for step 5.
+     * The flag is reset when SDK calls invalidate("client") after exchange.
      */
     if (scope === "all" && this._isExchangingCode) {
       /** Only clear tokens; preserve client and verifier for ongoing exchange. */
@@ -373,9 +344,8 @@ class BrowserOAuthProvider implements OAuthClientProvider {
       case "client":
         this._clientInfo = undefined;
         if (this._isOAuthStore(this._store)) {
-          await this._store.setClient(this._storeKey, {
-            clientId: "",
-          });
+          // Empty clientId signals deletion (OAuthStore has no deleteClient method)
+          await this._store.setClient(this._storeKey, { clientId: "" });
         }
         break;
       case "tokens":
@@ -385,6 +355,7 @@ class BrowserOAuthProvider implements OAuthClientProvider {
       case "verifier":
         this._codeVerifier = undefined;
         if (this._isOAuthStore(this._store)) {
+          // Empty session signals deletion (OAuthStore has no deleteSession method)
           await this._store.setSession(this._storeKey, {});
         }
         break;
@@ -411,7 +382,7 @@ class BrowserOAuthProvider implements OAuthClientProvider {
         state: this._pendingAuthState,
       };
 
-      /** Signal token exchange to protect state in invalidateCredentials(). */
+      /** Protect verifier from SDK's invalidate("all") during exchange. */
       this._isExchangingCode = true;
 
       this._pendingAuthCode = undefined;
@@ -420,37 +391,6 @@ class BrowserOAuthProvider implements OAuthClientProvider {
       return result;
     }
     return undefined;
-  }
-
-  private async _refreshTokens(): Promise<void> {
-    /** Serialize refresh attempts to prevent token corruption. */
-    if (this._refreshInProgress) {
-      await this._refreshInProgress;
-      return;
-    }
-
-    this._refreshInProgress = this._doRefreshTokens();
-    try {
-      await this._refreshInProgress;
-    } finally {
-      this._refreshInProgress = undefined;
-    }
-  }
-
-  private async _doRefreshTokens(): Promise<void> {
-    if (!this._tokens?.refresh_token) {
-      throw new Error("No refresh token available");
-    }
-
-    const clientInfo = await this.clientInformation();
-    if (!clientInfo?.client_id) {
-      throw new Error("No client information available for refresh");
-    }
-
-    /** TODO: Implement refresh when token endpoint URL is available from server metadata. */
-    throw new Error(
-      "Token refresh not yet implemented - requires token endpoint URL",
-    );
   }
 
   /** SDK constraint: addClientAuthentication() must not exist on this class. */

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,13 +6,12 @@
  * Creates a temporary localhost server to capture OAuth callbacks for CLI/desktop apps.
  */
 
-import open from "open";
 import { OAuthError } from "./errors";
 import { createCallbackServer, type CallbackResult } from "./server";
 import type { GetAuthCodeOptions } from "./types";
 
 export type { CallbackResult, CallbackServer, ServerOptions } from "./server";
-export { OAuthError } from "./errors";
+export { OAuthError, TimeoutError } from "./errors";
 export type { GetAuthCodeOptions } from "./types";
 
 // Storage implementations (backward compatibility)
@@ -25,7 +24,7 @@ export { mcp };
 
 /**
  * Captures OAuth authorization code via localhost callback.
- * Opens browser to auth URL, waits for provider redirect to localhost.
+ * Starts a temporary server, optionally launches auth URL, waits for redirect.
  *
  * @param input - Auth URL string or GetAuthCodeOptions with config
  * @returns Promise<CallbackResult> with code and params
@@ -34,17 +33,18 @@ export { mcp };
  *
  * @example
  * ```typescript
- * // Simple
- * const result = await getAuthCode('https://oauth.example.com/authorize?...');
- * console.log('Code:', result.code);
+ * import open from "open";
  *
- * // Custom port/timeout
+ * // With browser launch
  * const result = await getAuthCode({
  *   authorizationUrl: 'https://oauth.example.com/authorize?...',
- *   port: 8080,
- *   timeout: 60000,
- *   onRequest: (req) => console.log('Request:', req.url)
+ *   launch: open,
  * });
+ *
+ * // Headless (print URL, let user open manually)
+ * const url = 'https://oauth.example.com/authorize?...';
+ * console.log('Open:', url);
+ * const result = await getAuthCode({ authorizationUrl: url });
  * ```
  */
 export async function getAuthCode(
@@ -57,13 +57,13 @@ export async function getAuthCode(
     authorizationUrl,
     port = 3000,
     hostname = "localhost",
-    openBrowser = true,
     timeout = 30000,
     callbackPath = "/callback",
     successHtml,
     errorHtml,
     signal,
     onRequest,
+    launch,
   } = options;
 
   const server = createCallbackServer();
@@ -78,23 +78,8 @@ export async function getAuthCode(
       onRequest,
     });
 
-    if (openBrowser === true) {
-      await open(authorizationUrl);
-    } else if (openBrowser === false) {
-      // Test mode: trigger mock provider redirect without browser
-      fetch(authorizationUrl)
-        .then(async (response) => {
-          if (response.status === 302 || response.status === 301) {
-            const location = response.headers.get("Location");
-            if (location) {
-              await fetch(location);
-            }
-          }
-        })
-        .catch(() => {
-          // Ignore - tests may lack mock provider
-        });
-    }
+    // Best-effort launch: fire-and-forget, swallow errors
+    if (launch) void Promise.resolve(launch(authorizationUrl)).catch(() => {});
 
     const result = await server.waitForCallback(callbackPath, timeout);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,9 +78,9 @@ export async function getAuthCode(
       onRequest,
     });
 
-    if (openBrowser) {
+    if (openBrowser === true) {
       await open(authorizationUrl);
-    } else {
+    } else if (openBrowser === false) {
       // Test mode: trigger mock provider redirect without browser
       fetch(authorizationUrl)
         .then(async (response) => {

--- a/src/mcp-types.ts
+++ b/src/mcp-types.ts
@@ -73,13 +73,13 @@ export interface BrowserAuthOptions {
   callbackPath?: string; // Default: "/callback"
 
   store?: TokenStore; // Default: in-memory (lost on restart). Use OAuthStore for persistence.
-  storeKey?: string; // Storage key prefix. Default: "mcp-tokens"
+  storeKey?: string; // Storage key for token isolation. Default: "mcp-tokens"
 
-  openBrowser?: boolean | string; // Default: true. Set false for headless/CI environments.
+  /** Callback to launch the authorization URL. Omit for headless mode.
+   * Returns `unknown` to accept any launcher (e.g., `open` → `Promise<ChildProcess>`). */
+  launch?: (url: string) => unknown;
 
   authTimeout?: number; // Max wait for user authorization. Default: 300000ms (5 min)
-
-  usePKCE?: boolean; // Enable PKCE (RFC 7636). Default: true. Required for public clients.
 
   /** Custom HTML templates for callback pages. Supports {{placeholders}}. */
   successHtml?: string;

--- a/src/server.ts
+++ b/src/server.ts
@@ -7,6 +7,7 @@
 
 import type { Server as HttpServer } from "node:http";
 import type { IncomingMessage } from "node:http";
+import { TimeoutError } from "./errors";
 import { successTemplate, renderError } from "./templates";
 
 /**
@@ -179,7 +180,7 @@ abstract class BaseCallbackServer implements CallbackServer {
         new Promise<CallbackResult>((_, reject) => {
           timeoutId = setTimeout(() => {
             reject(
-              new Error(
+              new TimeoutError(
                 `OAuth callback timeout after ${timeout}ms waiting for ${path}`,
               ),
             );

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,20 +34,26 @@ export interface GetAuthCodeOptions {
 
   /**
    * Timeout in milliseconds to wait for OAuth callback.
-   * If no callback is received within this time, the operation will fail.
+   * Starts when the callback server is ready; launch timing does not delay it.
    * @default 30000
    */
   timeout?: number;
 
   /**
-   * Whether to automatically open the authorization URL in the user's default browser.
-   * Set to false for testing or when you want to handle browser opening manually.
-   * If set to "manual", the authorization URL will not be opened automatically and
-   * the return value will be an object containing a promise to get the auth code and
-   * a promise to cleanup resources (close the server).
-   * @default true
+   * Optional callback to launch the authorization URL.
+   * Called after the callback server starts, best-effort (errors are swallowed).
+   * If omitted, the library does nothing — caller is responsible for opening the URL.
+   *
+   * Returns `unknown` (not `void`) to accept any launcher without casting—e.g.,
+   * the `open` package returns `Promise<ChildProcess>`. Return value is ignored.
+   *
+   * @example
+   * ```typescript
+   * import open from "open";
+   * await getAuthCode({ authorizationUrl: url, launch: open });
+   * ```
    */
-  openBrowser?: boolean | "manual";
+  launch?: (url: string) => unknown;
 
   /**
    * Custom HTML content to display when authorization is successful.

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,9 +42,12 @@ export interface GetAuthCodeOptions {
   /**
    * Whether to automatically open the authorization URL in the user's default browser.
    * Set to false for testing or when you want to handle browser opening manually.
+   * If set to "manual", the authorization URL will not be opened automatically and
+   * the return value will be an object containing a promise to get the auth code and
+   * a promise to cleanup resources (close the server).
    * @default true
    */
-  openBrowser?: boolean;
+  openBrowser?: boolean | "manual";
 
   /**
    * Custom HTML content to display when authorization is successful.

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -2,10 +2,24 @@
 /* SPDX-License-Identifier: MIT */
 
 import { test, expect, beforeAll, afterAll } from "bun:test";
-import { getAuthCode } from "../src/index";
+import { getAuthCode, TimeoutError } from "../src/index";
 import type { Server } from "bun";
 
 let mockOAuthProvider: Server;
+
+/**
+ * Test launcher that simulates OAuth provider redirect.
+ * Fetches the auth URL and follows the redirect to trigger the callback.
+ */
+async function simulateOAuthRedirect(url: string): Promise<void> {
+  const response = await fetch(url);
+  if (response.status === 302 || response.status === 301) {
+    const location = response.headers.get("Location");
+    if (location) {
+      await fetch(location);
+    }
+  }
+}
 
 beforeAll(() => {
   // Setup mock OAuth provider server
@@ -87,15 +101,10 @@ test("complete OAuth authorization flow with mock provider", async () => {
       state: "random_state_123",
     });
 
-  // Call getAuthCode which will:
-  // 1. Start local server on port 3000
-  // 2. Open browser to authUrl (we'll disable this in test)
-  // 3. Mock provider redirects to callback
-  // 4. getAuthCode captures the code and returns
   const result = await getAuthCode({
     authorizationUrl: authUrl,
     port: 3000,
-    openBrowser: false, // Don't open browser in tests
+    launch: simulateOAuthRedirect,
   });
 
   // Verify the authorization code was captured
@@ -113,13 +122,12 @@ test("OAuth error handling - access denied", async () => {
       state: "state_456",
     });
 
-  // Test with throwOnError = true (default)
   let errorThrown = false;
   try {
     await getAuthCode({
       authorizationUrl: authUrl,
       port: 3001,
-      openBrowser: false,
+      launch: simulateOAuthRedirect,
     });
   } catch (error: any) {
     errorThrown = true;
@@ -140,13 +148,12 @@ test("OAuth error always throws OAuthError", async () => {
       response_type: "code",
     });
 
-  // Errors should always throw since throwOnError was removed
   let errorThrown = false;
   try {
     await getAuthCode({
       authorizationUrl: authUrl,
       port: 3002,
-      openBrowser: false,
+      launch: simulateOAuthRedirect,
     });
   } catch (error: any) {
     errorThrown = true;
@@ -167,18 +174,17 @@ test("successful authorization with string input", async () => {
       response_type: "code",
     });
 
-  // Test with simple string input, but disable browser opening for tests
   const result = await getAuthCode({
     authorizationUrl: authUrl,
     port: 3003,
-    openBrowser: false,
+    launch: simulateOAuthRedirect,
   });
 
   expect(result.code).toBe("test_auth_code_123");
   expect(result.state).toBeUndefined(); // No state provided
 });
 
-test("timeout handling with proper error message", async () => {
+test("timeout throws TimeoutError", async () => {
   // Use a URL that doesn't exist to ensure no callback is made
   const authUrl = "http://localhost:9999/nonexistent";
 
@@ -187,14 +193,12 @@ test("timeout handling with proper error message", async () => {
     await getAuthCode({
       authorizationUrl: authUrl,
       port: 3004,
-      timeout: 100, // Very short timeout
-      openBrowser: false,
+      timeout: 100,
     });
   } catch (error: any) {
     errorThrown = true;
-    expect(error.message).toContain(
-      "OAuth callback timeout after 100ms waiting for /callback",
-    );
+    expect(error).toBeInstanceOf(TimeoutError);
+    expect(error.name).toBe("TimeoutError");
   }
 
   expect(errorThrown).toBe(true);
@@ -214,7 +218,6 @@ test("abort signal handling", async () => {
       authorizationUrl: authUrl,
       port: 3005,
       signal: controller.signal,
-      openBrowser: false,
     });
   } catch (error: any) {
     errorThrown = true;
@@ -241,7 +244,7 @@ test("custom HTML templates", async () => {
     authorizationUrl: authUrl,
     port: 3006,
     successHtml: "<h1>Custom Success!</h1>",
-    openBrowser: false,
+    launch: simulateOAuthRedirect,
   });
 
   expect(result.code).toBe("test_auth_code_123");
@@ -262,11 +265,11 @@ test("onRequest callback is called", async () => {
   const result = await getAuthCode({
     authorizationUrl: authUrl,
     port: 3007,
+    launch: simulateOAuthRedirect,
     onRequest: (req) => {
       requestReceived = true;
       requestUrl = req.url;
     },
-    openBrowser: false,
   });
 
   expect(result.code).toBe("test_auth_code_123");
@@ -288,7 +291,6 @@ test("server cleanup on early stop", async () => {
       authorizationUrl: authUrl,
       port: 3008,
       signal: controller.signal,
-      openBrowser: false,
     });
   } catch (error: any) {
     errorThrown = true;


### PR DESCRIPTION
Fixes: https://github.com/kriasoft/oauth-callback/issues/27

### Summary

Replaces the `openBrowser: boolean` option with an explicit `launch` callback, making browser launching opt-in rather than opt-out. Callers now provide their own launcher function (e.g., the `open` package), giving full control over how the authorization URL is opened.

### Breaking Changes

**Before:**
```typescript
import { getAuthCode } from "oauth-callback";

// Browser opened automatically (opt-out via openBrowser: false)
const result = await getAuthCode({
  authorizationUrl: url,
  openBrowser: false, // Disable auto-open
});
```

**After:**
```typescript
import open from "open";
import { getAuthCode } from "oauth-callback";

// Explicit launch callback (opt-in)
const result = await getAuthCode({
  authorizationUrl: url,
  launch: open, // Pass launcher function
});

// Headless mode - just omit launch
console.log("Open:", url);
const result = await getAuthCode({ authorizationUrl: url });
```

### Changes

- **API**: Replace `openBrowser?: boolean` with `launch?: (url: string) => unknown`
- **API**: Remove `usePKCE` option (PKCE is always enabled via MCP SDK)
- **API**: Export `TimeoutError` for typed error handling
- **Internal**: Remove incomplete token refresh logic; expired tokens trigger re-auth
- **Internal**: Simplify `_doAuthorization` by removing retry logic
- **Docs**: Update all examples to use new API pattern

### Flow Diagram

```mermaid
sequenceDiagram
    participant App
    participant oauth-callback
    participant Browser
    participant OAuth Provider

    App->>oauth-callback: getAuthCode({ authorizationUrl, launch: open })
    oauth-callback->>oauth-callback: Start callback server on localhost
    oauth-callback->>App: Server ready
    oauth-callback->>Browser: launch(authorizationUrl)
    Browser->>OAuth Provider: User authorizes
    OAuth Provider->>oauth-callback: Redirect to localhost/callback?code=xxx
    oauth-callback->>App: Return { code, state }
```

### Migration Guide

| Before | After |
|--------|-------|
| `openBrowser: true` (default) | `launch: open` |
| `openBrowser: false` | Omit `launch` option |
| `usePKCE: true` | Remove (always enabled) |

### MCP Integration

```typescript
import open from "open";
import { browserAuth, fileStore } from "oauth-callback/mcp";

const authProvider = browserAuth({
  launch: open,           // Explicit browser launcher
  store: fileStore(),     // Persistent token storage
});
```