### PR TITLE
Split CI/CD workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,6 @@ name: CI/CD
 on:
   push:
     branches: [main]
-    tags: ["v*"]
   pull_request:
     branches: [main]
   workflow_dispatch:
@@ -112,50 +111,3 @@ jobs:
               bun build "$file" --target=node --outdir=/tmp/build-test > /dev/null && echo "✓ $file builds successfully"
             fi
           done
-
-  publish:
-    name: Publish to NPM
-    runs-on: ubuntu-latest
-    needs: [test, build, validate-examples]
-    if: startsWith(github.ref, 'refs/tags/v')
-    environment: npm
-    permissions:
-      contents: write
-      id-token: write
-
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
-        with:
-          node-version: "20"
-          registry-url: "https://registry.npmjs.org"
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
-      - run: bun install --frozen-lockfile
-      - run: |
-          bun run build:templates
-          bun run build
-
-      - name: Verify version match
-        run: |
-          PACKAGE_VERSION="v$(node -p "require('./package.json').version")"
-          TAG_VERSION="${GITHUB_REF#refs/tags/}"
-          if [ "$PACKAGE_VERSION" != "$TAG_VERSION" ]; then
-            echo "Error: Package version ($PACKAGE_VERSION) doesn't match tag ($TAG_VERSION)"
-            exit 1
-          fi
-          echo "✅ Version verified: $PACKAGE_VERSION"
-
-      - run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - uses: softprops/action-gh-release@v2
-        with:
-          name: Release ${{ github.ref_name }}
-          generate_release_notes: true
-          draft: false
-          prerelease: ${{ contains(github.ref_name, '-') }}
-          files: |
-            dist/**/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,59 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to publish (e.g. v1.2.3)"
+        required: true
+        type: string
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: npm
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref_name }}
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+
+      - run: bun install --frozen-lockfile
+      - run: bun run build:templates
+      - run: bun run build
+
+      - name: Verify version match
+        run: |
+          TAG_REF="${{ github.event.inputs.tag || github.ref_name }}"
+          PACKAGE_VERSION="v$(node -p \"require('./package.json').version\")"
+          if [ "$PACKAGE_VERSION" != "$TAG_REF" ]; then
+            echo "Error: Package version ($PACKAGE_VERSION) doesn't match tag ($TAG_REF)"
+            exit 1
+          fi
+          echo "✅ Version verified: $PACKAGE_VERSION"
+
+      - name: Verify dist output
+        run: |
+          if [ ! -f "dist/index.js" ]; then
+            echo "Error: dist/index.js not found"
+            exit 1
+          fi
+          if [ ! -f "dist/index.d.ts" ]; then
+            echo "Error: dist/index.d.ts not found"
+            exit 1
+          fi
+          echo "✅ Build output verified"
+
+      - run: npm publish --access public --provenance


### PR DESCRIPTION
### Changes

- Add `ci.yml` for test/build/validate (push/PR to main)
- Add `release.yml` for publishing (GitHub Release trigger)
- Remove `main.yml` (replaced by split workflows)

### Why

Separation of concerns:
- CI runs on every push/PR
- CD runs only on intentional GitHub Release events
- Cleaner provenance with OIDC (`id-token: write`) instead of `secrets.NPM_TOKEN`