### PR TITLE
Bugfix: Force close node server upon finishing response

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -281,6 +281,12 @@ class NodeCallbackServer extends BaseCallbackServer {
           const request = this.nodeToWebRequest(req, port, hostname);
           const response = this.handleRequest(request);
 
+          res.on("finish", () => {
+            // Force close all connections from server side after the response is fully flushed
+            // See: https://nodejs.org/api/http.html#event-finish-1
+            this.server?.closeAllConnections();
+          });
+
           res.shouldKeepAlive = false;
 
           res.writeHead(


### PR DESCRIPTION
- Relying on clients using the connection close header to close the connection leaves room for client bugs where the server can just hang until the timeout passes, this force clauses the connection completely from the server side but after flushing all the response data
- Follow up to: https://github.com/kriasoft/oauth-callback/issues/25
- Fixes: https://github.com/kriasoft/oauth-callback/issues/35

### Testing

1. Added this sample script: `examples/demo-node.js`
```js
import { getAuthCode } from "../dist/index.js";

const result = await getAuthCode({
  authorizationUrl: "https://github.com",
  port: 1234,
  openBrowser: true,
  timeout: 5 * 60 * 1000, // 5 minutes
});

console.log(result);
```

2. Used this to run: `npm run build && node examples/demo-node.js`
3. Opened this page manually: `http://localhost:1234/callback?code=123&status=456`